### PR TITLE
ENHANCE: Auto-load system fonts

### DIFF
--- a/coresdk/src/backend/utility_functions.cpp
+++ b/coresdk/src/backend/utility_functions.cpp
@@ -134,42 +134,42 @@ namespace splashkit_lib
         return result + filename;
     }
 
-	string base_fs_path()
-	{
-		#if WINDOWS
-			return get_env_var("SystemDrive");
-		#else
-			return "/";
-		#endif
-	}
+    string base_fs_path()
+    {
+        #if WINDOWS
+            return get_env_var("SystemDrive");
+        #else
+            return "/";
+        #endif
+    }
 
-	bool scan_dir_recursive(const string &directory, vector<string> &dest)
-	{
-		DIR *dirhnd;
-		struct dirent *dirpnt;
-		string fn_buffer;
+    bool scan_dir_recursive(const string &directory, vector<string> &dest)
+    {
+        DIR *dirhnd;
+        struct dirent *dirpnt;
+        string fn_buffer;
 
-		vector<string> directories;
-		directories.push_back(directory);
+        vector<string> directories;
+        directories.push_back(directory);
 
-		for (size_t i=0; i<directories.size(); ++i)
-		{
-			dirhnd = opendir(directories[i].c_str());
-			while ((dirpnt = readdir(dirhnd)) != NULL)
-			{
-				fn_buffer = string(dirpnt->d_name);
-				if (dirpnt->d_type == DT_DIR &&
-					fn_buffer != "." && fn_buffer != "..")
-					directories.push_back(directories[i] + "/" + fn_buffer);
-				else
-					dest.push_back(directories[i] + "/" + fn_buffer);
-			}
-			closedir(dirhnd);
-		}
+        for (size_t i=0; i<directories.size(); ++i)
+        {
+            dirhnd = opendir(directories[i].c_str());
+            while ((dirpnt = readdir(dirhnd)) != NULL)
+            {
+                fn_buffer = string(dirpnt->d_name);
+                if (dirpnt->d_type == DT_DIR &&
+                    fn_buffer != "." && fn_buffer != "..")
+                    directories.push_back(directories[i] + "/" + fn_buffer);
+                else
+                    dest.push_back(directories[i] + "/" + fn_buffer);
+            }
+            closedir(dirhnd);
+        }
 
-		return dest.size() > 0 ? true : false;
+        return dest.size() > 0 ? true : false;
 
-	}
+    }
 
     struct unknown_data {
         pointer_identifier id;

--- a/coresdk/src/backend/utility_functions.cpp
+++ b/coresdk/src/backend/utility_functions.cpp
@@ -23,6 +23,7 @@
 
 #ifndef WINDOWS
 #include <pwd.h>
+#include <dirent.h>
 #else
 #include <Windows.h>
 #include <Shlobj.h>
@@ -132,6 +133,43 @@ namespace splashkit_lib
 
         return result + filename;
     }
+
+	string base_fs_path()
+	{
+		#if WINDOWS
+			return get_env_var("SystemDrive");
+		#else
+			return "/";
+		#endif
+	}
+
+	bool scan_dir_recursive(const string &directory, vector<string> &dest)
+	{
+		DIR *dirhnd;
+		struct dirent *dirpnt;
+		string fn_buffer;
+
+		vector<string> directories;
+		directories.push_back(directory);
+
+		for (size_t i=0; i<directories.size(); ++i)
+		{
+			dirhnd = opendir(directories[i].c_str());
+			while ((dirpnt = readdir(dirhnd)) != NULL)
+			{
+				fn_buffer = string(dirpnt->d_name);
+				if (dirpnt->d_type == DT_DIR &&
+					fn_buffer != "." && fn_buffer != "..")
+					directories.push_back(directories[i] + "/" + fn_buffer);
+				else
+					dest.push_back(directories[i] + "/" + fn_buffer);
+			}
+			closedir(dirhnd);
+		}
+
+		return dest.size() > 0 ? true : false;
+
+	}
 
     struct unknown_data {
         pointer_identifier id;

--- a/coresdk/src/backend/utility_functions.cpp
+++ b/coresdk/src/backend/utility_functions.cpp
@@ -145,6 +145,11 @@ namespace splashkit_lib
 
     bool scan_dir_recursive(const string &directory, vector<string> &dest)
     {
+        //Windows support is not yet implemented.
+        #if WINDOWS 
+            return false;
+        #endif        
+
         DIR *dirhnd;
         struct dirent *dirpnt;
         string fn_buffer;

--- a/coresdk/src/backend/utility_functions.h
+++ b/coresdk/src/backend/utility_functions.h
@@ -185,6 +185,8 @@ collection.erase(collection.begin());\
     bool try_str_to_double(string str, double &result);
     
     string to_lower (string str);
+	string base_fs_path();
+	bool scan_dir_recursive(const string &directory, vector<string> &dest);
     
     double rad_to_deg(double radians);
     

--- a/coresdk/src/backend/utility_functions.h
+++ b/coresdk/src/backend/utility_functions.h
@@ -185,8 +185,8 @@ collection.erase(collection.begin());\
     bool try_str_to_double(string str, double &result);
     
     string to_lower (string str);
-	string base_fs_path();
-	bool scan_dir_recursive(const string &directory, vector<string> &dest);
+    string base_fs_path();
+    bool scan_dir_recursive(const string &directory, vector<string> &dest);
     
     double rad_to_deg(double radians);
     

--- a/coresdk/src/coresdk/text.cpp
+++ b/coresdk/src/coresdk/text.cpp
@@ -164,41 +164,41 @@ namespace splashkit_lib
         return get_font_style(font_named(name));
     }
 
-	string get_system_font_path()
-	{
-		string base_fp = base_fs_path();
-		
-		#if __linux__
-			base_fp += "usr/share/fonts";
-		#elif WINDOWS
-			base_fp += "Windows\Fonts";
-		#else
-			base_fp += "System/Library/Fonts";
-		#endif
+    string get_system_font_path()
+    {
+        string base_fp = base_fs_path();
 
-		return base_fp;
-	}
+        #if __linux__
+            base_fp += "usr/share/fonts";
+        #elif WINDOWS
+            base_fp += "Windows\Fonts";
+        #else
+            base_fp += "System/Library/Fonts";
+        #endif
 
-	string find_system_font_path(string name)
-	{
-		//Find all files in directory.
-		vector<string> files;
-		scan_dir_recursive(get_system_font_path(), files);
+        return base_fp;
+    }
 
-		transform(name.begin(), name.end(), name.begin(), ::tolower);
+    string find_system_font_path(string name)
+    {
+        //Find all files in directory.
+        vector<string> files;
+        scan_dir_recursive(get_system_font_path(), files);
 
-		for (size_t i=0; i<files.size(); ++i)
-		{
-			int fi = files[i].find_last_of('/') +1;
-			int fd = files[i].find_last_of('.') - fi;
-			string file_name = files[i].substr(fi, fd);
-			transform(file_name.begin(), file_name.end(), file_name.begin(), ::tolower);
-			if (file_name == name)
-				return files[i];
-		}
+        transform(name.begin(), name.end(), name.begin(), ::tolower);
 
-		return "";
-	}
+        for (size_t i=0; i<files.size(); ++i)
+        {
+            int fi = files[i].find_last_of('/') +1;
+            int fd = files[i].find_last_of('.') - fi;
+            string file_name = files[i].substr(fi, fd);
+            transform(file_name.begin(), file_name.end(), file_name.begin(), ::tolower);
+            if (file_name == name)
+                return files[i];
+        }
+
+        return "";
+    }
 
     font load_font(const string &name, const string &filename)
     {
@@ -216,13 +216,13 @@ namespace splashkit_lib
 
                 if ( ! file_exists(file_path) )
                 {
-					file_path = find_system_font_path(filename);
+                    file_path = find_system_font_path(filename);
 
-					if ( ! file_exists(file_path) )
-					{
+                    if ( ! file_exists(file_path) )
+                    {
 						LOG(WARNING) << cat({ "Unable to locate file for ", name, " (", file_path, ")"});
-						return nullptr;
-					}
+                        return nullptr;
+                    }
                 }
             }
         }

--- a/coresdk/src/coresdk/text.cpp
+++ b/coresdk/src/coresdk/text.cpp
@@ -181,7 +181,12 @@ namespace splashkit_lib
 
     string find_system_font_path(string name)
     {
-        //Find all files in directory.
+#ifdef WINDOWS
+#define PATH_SEP "\\"
+#else
+#define PATH_SEP "/"
+#endif
+
         vector<string> files;
         scan_dir_recursive(get_system_font_path(), files);
 
@@ -189,7 +194,7 @@ namespace splashkit_lib
 
         for (size_t i=0; i<files.size(); ++i)
         {
-            int fi = files[i].find_last_of('/') +1;
+            int fi = files[i].find_last_of(PATH_SEP) +1;
             int fd = files[i].find_last_of('.') - fi;
             string file_name = files[i].substr(fi, fd);
             transform(file_name.begin(), file_name.end(), file_name.begin(), ::tolower);

--- a/coresdk/src/coresdk/text.cpp
+++ b/coresdk/src/coresdk/text.cpp
@@ -164,6 +164,42 @@ namespace splashkit_lib
         return get_font_style(font_named(name));
     }
 
+	string get_system_font_path()
+	{
+		string base_fp = base_fs_path();
+		
+		#if __linux__
+			base_fp += "usr/share/fonts";
+		#elif WINDOWS
+			base_fp += "Windows\Fonts";
+		#else
+			base_fp += "System/Library/Fonts";
+		#endif
+
+		return base_fp;
+	}
+
+	string find_system_font_path(string name)
+	{
+		//Find all files in directory.
+		vector<string> files;
+		scan_dir_recursive(get_system_font_path(), files);
+
+		transform(name.begin(), name.end(), name.begin(), ::tolower);
+
+		for (size_t i=0; i<files.size(); ++i)
+		{
+			int fi = files[i].find_last_of('/') +1;
+			int fd = files[i].find_last_of('.') - fi;
+			string file_name = files[i].substr(fi, fd);
+			transform(file_name.begin(), file_name.end(), file_name.begin(), ::tolower);
+			if (file_name == name)
+				return files[i];
+		}
+
+		return "";
+	}
+
     font load_font(const string &name, const string &filename)
     {
         if (has_font(name)) return font_named(name);
@@ -180,8 +216,13 @@ namespace splashkit_lib
 
                 if ( ! file_exists(file_path) )
                 {
-                    LOG(WARNING) << cat({ "Unable to locate file for ", name, " (", file_path, ")"});
-                    return nullptr;
+					file_path = find_system_font_path(filename);
+
+					if ( ! file_exists(file_path) )
+					{
+						LOG(WARNING) << cat({ "Unable to locate file for ", name, " (", file_path, ")"});
+						return nullptr;
+					}
                 }
             }
         }

--- a/coresdk/src/coresdk/text.h
+++ b/coresdk/src/coresdk/text.h
@@ -76,6 +76,22 @@ namespace splashkit_lib
      */
     font_style get_font_style(const string &name);
 
+	/**
+	 * @brief Gets the system font path.
+	 * 
+	 * @returns Returns the current `system font path`.
+	 */
+	string get_system_font_path();
+
+	/**
+	 * @brief Gets the system font path for a given font name.
+	 * 
+	 * @param name			The name of the font to locate.
+	 * 
+	 * @returns Returns the system font path for a given font, or an empty string.
+	 */
+	string find_system_font_path(string name);
+
     /**
      * @brief Loads a new font from a file.
      *

--- a/coresdk/src/coresdk/text.h
+++ b/coresdk/src/coresdk/text.h
@@ -76,21 +76,21 @@ namespace splashkit_lib
      */
     font_style get_font_style(const string &name);
 
-	/**
-	 * @brief Gets the system font path.
-	 * 
-	 * @returns Returns the current `system font path`.
-	 */
-	string get_system_font_path();
+    /**
+     * @brief Gets the system font path.
+     * 
+     * @returns Returns the current `system font path`.
+     */
+    string get_system_font_path();
 
-	/**
-	 * @brief Gets the system font path for a given font name.
-	 * 
-	 * @param name			The name of the font to locate.
-	 * 
-	 * @returns Returns the system font path for a given font, or an empty string.
-	 */
-	string find_system_font_path(string name);
+    /**
+     * @brief Gets the system font path for a given font name.
+     * 
+     * @param name			The name of the font to locate.
+     * 
+     * @returns Returns the system font path for a given font, or an empty string.
+     */
+    string find_system_font_path(string name);
 
     /**
      * @brief Loads a new font from a file.


### PR DESCRIPTION
This PR enhances SplashKit to load system installed fonts if the specified font does not exist as a file in `Resources/fonts`. It has been tested on macOS High Sierra, Ubuntu 17.10 and 18.04. Windows support is not contained in this PR (but a fallback is and it could easily be added).