### PR TITLE
ENHANCE: Prevent fatal crash when loading JSON file that doesn't exist

### DIFF
--- a/coresdk/src/coresdk/json.cpp
+++ b/coresdk/src/coresdk/json.cpp
@@ -99,6 +99,12 @@ namespace splashkit_lib
     json json_from_file(const string &filename)
     {
         string result = file_as_string(filename, JSON_RESOURCE);
+		if (result == "")
+		{
+			LOG(WARNING) << "No input received when trying to open json from file " \
+				<< filename << ". Does the file exist?";
+			return create_json();
+		}
 
         return json_from_string(result);
     };

--- a/coresdk/src/coresdk/json.cpp
+++ b/coresdk/src/coresdk/json.cpp
@@ -99,12 +99,12 @@ namespace splashkit_lib
     json json_from_file(const string &filename)
     {
         string result = file_as_string(filename, JSON_RESOURCE);
-		if (result == "")
-		{
-			LOG(WARNING) << "No input received when trying to open json from file " \
-				<< filename << ". Does the file exist?";
-			return create_json();
-		}
+        if (result == "")
+        {
+            LOG(WARNING) << "No input received when trying to open json from file " \
+                << filename << ". Does the file exist?";
+            return create_json();
+        }
 
         return json_from_string(result);
     };

--- a/coresdk/src/coresdk/json.cpp
+++ b/coresdk/src/coresdk/json.cpp
@@ -99,7 +99,7 @@ namespace splashkit_lib
     json json_from_file(const string &filename)
     {
         string result = file_as_string(filename, JSON_RESOURCE);
-        if (result == "")
+        if (result.length() == 0)
         {
             LOG(WARNING) << "No input received when trying to open json from file " \
                 << filename << ". Does the file exist?";


### PR DESCRIPTION
This PR prevents SplashKit from crashing when `json_from_file` is called either referencing a file that does not yet exist, or a file that cannot be read.

Previous behaviour:

```sh
$ ./json_test
(28/10/2018) ERROR -> Invalid JSON string passed to create_json
 [/Users/richarddenton/git/splashkit-core/coresdk/src/coresdk/json.cpp:40]
```

New behaviour:

```sh
$ ./json_test
2018-09-28 17:24:02,340 WARNING [default] No input received when trying to open json from file example.json. Does the file exist?
```

Example program:

```c++
#include "splashkit.h"

int main()
{
    json j = json_from_file("example.json");
    return 0;
}
```