### PR TITLE
Continuous Sound Effect Playback

### DIFF
--- a/coresdk/src/coresdk/sound.cpp
+++ b/coresdk/src/coresdk/sound.cpp
@@ -133,15 +133,16 @@ namespace splashkit_lib
             return;
         }
 
-        // dont play if loops = 0
-        if (times <= 0) return;
+        // convert to SDL-compatible loops count
+        // (-1 = inf, 0 = once, 1 = twice)
+        int loops;
+        if(times == -1) loops = -1;
+        else if(times <= 0) return;
+        else loops = times - 1;
 
         // correct volume to be between 0 and 1
         if (volume < 0) volume = 0;
         else if (volume > 1) volume = 1;
-
-        // alter repeats for multiple loops
-        int loops = times - 1;
 
         // play the effect, seaching for a channel
         sk_play_sound(&effect->effect, loops, volume);


### PR DESCRIPTION
In https://www.splashkit.io/articles/guides/tags/audio/about-audio/, the example code at the end of the guide demonstrates that a sound effect can be played continuously by calling
`sndEffect.Play(-1, 0.1f)`.

However, SplashKit does not allow values below 1 to be passed to the `times` argument of `play_sound_effect` (see removed line 137).

sk_play_sound will pass the `loops` argument straight through to SDL's `Mix_PlayChannel` function, which expects `-1` for indefinite playback, `0` to play once, `1` to play twice, etc.
(See https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_28.html.)

As such, the only change we need to make is to allow `-1` as a permissible value for the `times` argument, and offset all other values by -1.