### PR TITLE
NEW: Operator Overloads for point_2d and vector_2d

### DIFF
--- a/coresdk/src/coresdk/point_geometry.cpp
+++ b/coresdk/src/coresdk/point_geometry.cpp
@@ -238,4 +238,27 @@ namespace splashkit_lib
         return point_point_distance(pt, closest_point_on_line(pt, l));
     }
     
+    /**
+     * Operator Overloading
+     */
+    point_2d point_2d::operator+(const point_2d& a) const
+    {
+        return point_at(x+a.x, y+a.y);
+    }
+
+    point_2d point_2d::operator-(const point_2d& a) const
+    {
+        return point_at(x-a.x, y-a.y);
+    }
+
+    point_2d point_2d::operator+(const vector_2d& a) const
+    {
+        return point_at(x+a.x, y+a.y);
+    }
+
+    point_2d point_2d::operator-(const vector_2d& a) const
+    {
+        return point_at(x-a.x, y-a.y);
+    }
+    
 }

--- a/coresdk/src/coresdk/types.h
+++ b/coresdk/src/coresdk/types.h
@@ -113,6 +113,12 @@ namespace splashkit_lib
     struct point_2d
     {
         double x, y;
+
+        // Operator Overloads
+        point_2d operator+(const point_2d& a) const;
+        point_2d operator-(const point_2d& a) const;
+        point_2d operator+(const vector_2d& a) const;
+        point_2d operator-(const vector_2d& a) const;
     };
 
     /**
@@ -134,6 +140,10 @@ namespace splashkit_lib
     {
         double x;
         double y;
+
+        // Operator Overloads
+        vector_2d operator+(const vector_2d& a) const;
+        vector_2d operator-(const vector_2d& a) const;
     };
 
     /**

--- a/coresdk/src/coresdk/types.h
+++ b/coresdk/src/coresdk/types.h
@@ -97,31 +97,6 @@ namespace splashkit_lib
     typedef struct _animation_data *animation;
 
     /**
-     * A Point2D represents an location in Cartesian coordinates (x,y).
-     * The x value represents the distance from the left edge of the window or bitmap, increasing
-     * in value as you travel right. The y value represents the distance from the top
-     * edge of the window or bitmap, and increases as you travel down toward the bottom.
-     *
-     * Point2D is a great way to keep track of the location of something in a 2D space like
-     * a Window or Bitmap.
-     *
-     * @field x   The distance from the left side of the bitmap or window (
-     *            increasing as you go to the right)
-     * @field y   The distance from the top of a bitmap or window (increasing
-     *            as you go down).
-     */
-    struct point_2d
-    {
-        double x, y;
-
-        // Operator Overloads
-        point_2d operator+(const point_2d& a) const;
-        point_2d operator-(const point_2d& a) const;
-        point_2d operator+(const vector_2d& a) const;
-        point_2d operator-(const vector_2d& a) const;
-    };
-
-    /**
      * Vectors represent a direction and distance, and can be visualised as an
      * arrow from one point to another in 2 dimensional space. Internally, the
      * `vector_2d` is stored as its x and y components.
@@ -144,6 +119,31 @@ namespace splashkit_lib
         // Operator Overloads
         vector_2d operator+(const vector_2d& a) const;
         vector_2d operator-(const vector_2d& a) const;
+    };
+
+    /**
+     * A Point2D represents an location in Cartesian coordinates (x,y).
+     * The x value represents the distance from the left edge of the window or bitmap, increasing
+     * in value as you travel right. The y value represents the distance from the top
+     * edge of the window or bitmap, and increases as you travel down toward the bottom.
+     *
+     * Point2D is a great way to keep track of the location of something in a 2D space like
+     * a Window or Bitmap.
+     *
+     * @field x   The distance from the left side of the bitmap or window (
+     *            increasing as you go to the right)
+     * @field y   The distance from the top of a bitmap or window (increasing
+     *            as you go down).
+     */
+    struct point_2d
+    {
+        double x, y;
+
+        // Operator Overloads
+        point_2d operator+(const point_2d& a) const;
+        point_2d operator-(const point_2d& a) const;
+        point_2d operator+(const vector_2d& a) const;
+        point_2d operator-(const vector_2d& a) const;
     };
 
     /**

--- a/coresdk/src/coresdk/vector_2d.cpp
+++ b/coresdk/src/coresdk/vector_2d.cpp
@@ -543,4 +543,18 @@ namespace splashkit_lib
         else if (v.y >= rect.y + rect.height) return false;
         else return true;
     }
+
+    /**
+     * Operator Overloading
+     */
+    vector_2d vector_2d::operator+(const vector_2d& a) const
+    {
+        return vector_to(x+a.x, y+a.y);
+    }
+
+    vector_2d vector_2d::operator-(const vector_2d& a) const
+    {
+        return vector_to(x-a.x, y-a.y);
+    }
+
 }


### PR DESCRIPTION
Some suggested extensions to point_2d and vector_2d structs. Although there are functions that exist that do the same thing, it feels natural and would be a welcome feature (from my experience with using these heavily) to be able to use operators on these, such as:
point_2d moved_point = pt1 + vt1; 
// where pt1 is a point_2d and vt1 is a vector_2d