### PR TITLE
Improve drawing_options documentation

### DIFF
--- a/coresdk/src/coresdk/types.h
+++ b/coresdk/src/coresdk/types.h
@@ -224,7 +224,7 @@ namespace splashkit_lib
 
     /**
      * Drawing options allow you to customise drawing options. These should be
-     * initialised using the drawing option functions.
+     * initialised using the drawing option functions such as `option_defaults`.
      *
      * @field dest            The destination of the drawing: a window or bitmap.
      * @field scale_x         How much x values are scaled.


### PR DESCRIPTION
Add `option_defaults` as an example of the drawing option function to so that it's easier to find the relevant documentation.