### PR TITLE
Fix json type documentation

### DIFF
--- a/coresdk/src/coresdk/json.h
+++ b/coresdk/src/coresdk/json.h
@@ -41,8 +41,8 @@ namespace splashkit_lib
      *   `json_from_string(string s)` or `json_from_file(json j)`
      *
      *
-     *   - and must be released using `free_json()` (to release a specific `json object)
-     *   or `free_all_json()` (to release all loaded `json objects).
+     *   - and must be released using `free_json()` (to release a specific `json` object)
+     *   or `free_all_json()` (to release all loaded `json` objects).
      *
      *
      * @attribute class json


### PR DESCRIPTION
There were some missing ` in the json type documentation.