### PR TITLE
Add custom repsonse headers

### DIFF
--- a/coresdk/src/backend/backend_types.h
+++ b/coresdk/src/backend/backend_types.h
@@ -235,7 +235,8 @@ namespace splashkit_lib
         char                *message;
         unsigned long       message_size;
         http_status_code    code;
-        
+        vector<string>      headers;
+
         semaphore           response_sent;
     };
 

--- a/coresdk/src/backend/web_server_driver.cpp
+++ b/coresdk/src/backend/web_server_driver.cpp
@@ -92,17 +92,25 @@ namespace splashkit_lib
         servers[port]->request_queue.put(r); // Add request to concurrent queue
         r->control.acquire(); // Waits until user returns response.
 
+        // Concatenate headers vector
+        string headers;
+        for (string &header : r->response->headers) {
+          headers.append(header.append("\r\n"));
+        }
+
         // Send HTTP reply to the client
         mg_printf(conn,
                   "HTTP/1.1 %d\r\n"
                   "Content-Type: %s\r\n"
                   "Connection: close\r\n"
                   "Content-Length: %lu\r\n" // Always set Content-Length
+                  "%s"
                   "\r\n"
                   "%s",
                   r->response->code,
                   r->response->content_type.c_str(),
                   r->response->message_size,
+                  headers.c_str(),
                   r->response->message);
 
         r->response->response_sent.release();
@@ -215,21 +223,21 @@ namespace splashkit_lib
             sk_flush_request(server->last_request);
             delete server->last_request;
         }
-        
+
         sk_http_request *request;
         while (server->request_queue.try_take(request))
         {
             sk_flush_request(request);
         }
-        
+
         _web_server_ctx_data *user_data = static_cast<_web_server_ctx_data *>(mg_get_user_data(server->ctx));
         if ( user_data )
         {
             delete user_data;
         }
-        
+
         mg_stop(server->ctx);
-        
+
         auto it = servers.find(server->port);
         if (it != servers.end())
         {

--- a/coresdk/src/coresdk/web_server.cpp
+++ b/coresdk/src/coresdk/web_server.cpp
@@ -102,7 +102,8 @@ namespace splashkit_lib
         delete resp.message;
     }
 
-    void send_response(http_request r, http_status_code code, const string &message, const string &content_type) {
+    void send_response(http_request r, http_status_code code, const string &message, const string &content_type)
+    {
       send_response(r, code, message, content_type, {});
     }
 

--- a/coresdk/src/coresdk/web_server.cpp
+++ b/coresdk/src/coresdk/web_server.cpp
@@ -80,10 +80,10 @@ namespace splashkit_lib
 
     void send_response(http_request r, const string &message)
     {
-        send_response(r, HTTP_STATUS_OK, message, "text/plain");
+        send_response(r, HTTP_STATUS_OK, message, "text/plain", {});
     }
 
-    void send_response(http_request r, http_status_code code, const string &message, const string &content_type)
+    void send_response(http_request r, http_status_code code, const string &message, const string &content_type, const vector<string> &headers)
     {
         sk_http_response resp;
 
@@ -92,6 +92,7 @@ namespace splashkit_lib
         resp.message_size = message.size();
         resp.content_type = content_type;
         resp.code = code;
+        resp.headers = headers;
 
         _send_response(r, &resp);
 
@@ -99,6 +100,10 @@ namespace splashkit_lib
         resp.response_sent.acquire();
         // Safe to delete
         delete resp.message;
+    }
+
+    void send_response(http_request r, http_status_code code, const string &message, const string &content_type) {
+      send_response(r, code, message, content_type, {});
     }
 
     void send_response(http_request r, http_status_code code, const string &message)
@@ -110,7 +115,6 @@ namespace splashkit_lib
     {
         send_response(r, HTTP_STATUS_OK, json_to_string(j), "application/json");
     }
-
 
     void send_response(http_request r, http_status_code code)
     {
@@ -127,12 +131,12 @@ namespace splashkit_lib
         string file = file_as_string(filename, SERVER_RESOURCE);
         send_response(r, HTTP_STATUS_OK, file, content_type);
     }
-    
+
     void send_javascript_file_response(http_request r, const string &filename)
     {
         send_file_response(r, filename, "text/javascript");
     }
-    
+
     void send_css_file_response(http_request r, const string &filename)
     {
         send_file_response(r, filename, "text/css");
@@ -153,7 +157,7 @@ namespace splashkit_lib
 
         return r->uri;
     }
-    
+
     string request_query_string(http_request r)
     {
         if (INVALID_PTR(r, HTTP_REQUEST_PTR))
@@ -161,13 +165,13 @@ namespace splashkit_lib
             LOG(WARNING) << "Getting request uri with invalid request";
             return "";
         }
-        
+
         return r->query_string;
     }
 
 // From: https://cboard.cprogramming.com/c-programming/13752-how-parse-query_string.html
 #define TO_HEX(Y) (Y>='0'&&Y<='9'?Y-'0':Y-'A'+10)
-    
+
     string request_query_parameter(http_request r, const string &name, const string &default_value)
     {
         if (INVALID_PTR(r, HTTP_REQUEST_PTR))
@@ -175,16 +179,16 @@ namespace splashkit_lib
             LOG(WARNING) << "Getting query parameter with invalid request";
             return "";
         }
-        
+
         string query_string = r->query_string;
-        
+
         size_t idx = query_string.find(name + "=");
-        
+
         if ( idx == string::npos) return default_value;
-        
+
         auto iter = query_string.begin() + idx + name.length() + 1;
         stringstream result;
-        
+
         while ( iter < query_string.end() )
         {
             if ( *iter == '%' )
@@ -204,13 +208,13 @@ namespace splashkit_lib
             {
                 result << *iter;
             }
-            
+
             iter++;
         }
-        
+
         return result.str();
     }
-    
+
     bool request_has_query_parameter(http_request r, const string &name)
     {
         if (INVALID_PTR(r, HTTP_REQUEST_PTR))
@@ -218,10 +222,10 @@ namespace splashkit_lib
             LOG(WARNING) << "Getting query parameter with invalid request";
             return "";
         }
-        
+
         return r->query_string.find(name + "=") != string::npos;
     }
-    
+
 #undef TO_HEX
 
     http_method request_method(http_request r)

--- a/coresdk/src/coresdk/web_server.h
+++ b/coresdk/src/coresdk/web_server.h
@@ -126,6 +126,23 @@ namespace splashkit_lib
      * @param code          The [HTTP status code](See https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) to be sent.
      * @param message       The messsage, in the form of a `http_response`, to be sent.
      * @param content_type  The content type of the response.
+     * @param headers       The response headers
+     *
+     * @attribute class http_request
+     * @attribute self  r
+     * @attribute method send_response
+     *
+     * @attribute suffix  with_status_and_content_type
+     */
+    void send_response(http_request r, http_status_code code, const string &message, const string &content_type, const vector<string> &headers);
+
+  /**
+     * Sends a message to a given `http_request` with the specified content type.
+     *
+     * @param r             The `http_request` to send the response to
+     * @param code          The [HTTP status code](See https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) to be sent.
+     * @param message       The messsage, in the form of a `http_response`, to be sent.
+     * @param content_type  The content type of the response.
      *
      * @attribute class http_request
      * @attribute self  r
@@ -212,7 +229,7 @@ namespace splashkit_lib
      * @attribute method send_file_response
      */
     void send_file_response(http_request r, const string &filename, const string &content_type);
-    
+
     /**
      * Serves a HTML file to the given `http_request`.
      *
@@ -234,7 +251,7 @@ namespace splashkit_lib
      * @attribute method send_javascript_file_response
      */
     void send_javascript_file_response(http_request r, const string &filename);
-    
+
     /**
      * Serves a css file to the given `http_request`.
      *
@@ -245,7 +262,7 @@ namespace splashkit_lib
      * @attribute method send_css_file_response
      */
     void send_css_file_response(http_request r, const string &filename);
-    
+
     /**
      * Returns the server URI of the client request.
      *
@@ -257,7 +274,7 @@ namespace splashkit_lib
      * @attribute getter uri
      */
     string request_uri(http_request r);
-    
+
     /**
      * Returns the URI query string of the client request.
      *
@@ -284,7 +301,7 @@ namespace splashkit_lib
      * @attribute method query_parameter
      */
     string request_query_parameter(http_request r, const string &name, const string &default_value);
-    
+
     /**
      * Returns true if the parameter exists in the query string.
      *
@@ -309,7 +326,7 @@ namespace splashkit_lib
      * @attribute getter method
      */
     http_method request_method(http_request r);
-    
+
 
     /**
      * Returns the body of the request.

--- a/coresdk/src/test/Resources/server/index.html
+++ b/coresdk/src/test/Resources/server/index.html
@@ -13,5 +13,6 @@
 <h2>'Client' Side Consumers</h2>
 <a href="/post_person">/post_person</a><br />
 <a href="/get_person">/get_person</a><br />
+<a href="/login">/login</a><br />
 </body>
 </html>

--- a/coresdk/src/test/test_web_service.cpp
+++ b/coresdk/src/test/test_web_service.cpp
@@ -168,9 +168,16 @@ void get_person_route(http_request request, string uri)
     send_html_file_response(request, "get.html");
 }
 
+void api_login_route(http_request request, string uri)
+{
+  send_response(request, HTTP_STATUS_OK, "Check your cookies", "text", {"Set-Cookie: user=admin"});
+}
+
 void add_routes()
 {
     routes[HTTP_GET_METHOD].insert({"", root_route});
+
+    routes[HTTP_GET_METHOD].insert({"login", api_login_route});
 
     routes[HTTP_GET_METHOD].insert({"names", names_get_routes});
     routes[HTTP_POST_METHOD].insert({"names", names_post_routes});

--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -66,7 +66,7 @@ else()
                    -lFLAC \
                    -lvorbis \
                    -lz \
-                   -lpng12 \
+                   -lpng16 \
                    -lvorbisfile \
                    -lmikmod \
                    -logg \


### PR DESCRIPTION
Add the ability to send custom response headers from a web server. Closes #116

- [x] Add headers field to `sk_http_request`
- [x] Add header handling to `being_request_handler`
- [x] Add a variant of `send_response` to include a vector of headers to mimic the behaviour of `http_post`

To Do:

- [x] ~~Update libpng version for linux (see #117)~~
- [ ] Add HTTP 3xx codes to `http_status_code` (see #119) 
- [x] ~~Create a test as apart of the web service test~~
- [ ] Regenerate the language interfaces (if @macite could do this that would be awesome)