### PR TITLE
Add request_headers

### DIFF
--- a/coresdk/src/coresdk/web_server.cpp
+++ b/coresdk/src/coresdk/web_server.cpp
@@ -246,6 +246,17 @@ namespace splashkit_lib
         return r->body;
     }
 
+    vector<string> request_headers(http_request r)
+    {
+        if (INVALID_PTR(r, HTTP_REQUEST_PTR))
+        {
+            LOG(WARNING) << "Getting request headers on an invalid request";
+            return {};
+        }
+
+        return r->headers;
+    }
+
     vector<string> request_uri_stubs(http_request r)
     {
         string uri = request_uri(r);

--- a/coresdk/src/coresdk/web_server.h
+++ b/coresdk/src/coresdk/web_server.h
@@ -323,6 +323,20 @@ namespace splashkit_lib
      */
     string request_body(http_request r);
 
+
+    /**
+     * Returns the headers of the request.
+     *
+     * @param r A request object.
+     *
+     * @returns The headers of the request.
+     *
+     * @attribute class http_request
+     * @attribute getter headers
+     */
+    vector<string> request_headers(http_request r);
+
+
     /**
      * Returns an array of strings representing each stub of the URI.
      *


### PR DESCRIPTION
Add the `request_headers` function to get a vector of the headers for a request.

To Do:
- [ ] Regenerate language interfaces