### PR TITLE
Added (hopefully complete) instructions for building Splashkit on Windows.

### DIFF
--- a/setting-up-splashkit-dev.md
+++ b/setting-up-splashkit-dev.md
@@ -40,46 +40,53 @@ If you are reading this then you have probably already found the Splashkit-core 
 2. Install [MSYS2](https://www.msys2.org/) subsystem and follow fairly self-explanatory installer instructions &ndash; use defaults if unsure, **DO NOT INSTALL TO DIRECTORY WITH SPACES!**
 3. Install core Splashkit SDK
     - Go into MSYS2 terminal emulator and install [Git](https://git-scm.com/) over MSYS2 subsystem by typing :
-```
+    ```
 pacman -S git --noconfirm --disable-download-timeout
 ```
     - Now clone and install Splashkit via install-scripts:
-```
+    ```
 bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)
 ```
     - Restart terminal, type
-```
+    ```
 skm
 ```
-in terminal after restarting to verify successful install.
+    in terminal after restarting to verify successful install.
 4. Install [VSCode](https://code.visualstudio.com/).
 5. Install language tools (compilers / libs):
     - For C#, install the DotNet core sdk.
     - For C++, install GNU Compiler Collection (GCC) - g++ and clang++ in MSYS2.
       - Run the following command in terminal:
-```
+      ```
 pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb
 ```
       - Do not run compiler from main MSYS2 MSYS terminal, instead run from MSYS2 MinGW32 or MinGW64 terminals.
 6. Install  remaining tools to build Splashkit:
     - Install cmake:
-```
+    ```
 pacman -S mingw-w64-x86_64-cmake
 ```
     - install make:
-```
+    ```
 pacman -S mingw-w64-x86_64-make
 ```
 7. Build the test project:
     - Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type:
+    ```
+cd projects/cmake
 ```
-cd projects/cmake``` ```cmake -G "Unix Makefiles" .``` ```make
+    ```
+cmake -G "Unix Makefiles" .
+```
+    ```
+make
 ```
     - Note: if the above does not work, try using the actual unix make and cmake installations, rather than the MinGw-specific ones; but do not try a combination of both. Remove packages with
-```
+    ```
 pacman -Rs <package>
-``` and
 ```
+    and
+    ```
 pacman -S cmake make
 ```
 8. Run the test program by executing

--- a/setting-up-splashkit-dev.md
+++ b/setting-up-splashkit-dev.md
@@ -20,19 +20,19 @@ If you are reading this then you have probably already found the Splashkit-core 
 ### Mac
 
 1. Install brew.
-  -  In Terminal run this command: ```/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"```.
+  -  In Terminal run this command:   ```/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"  ```.
   -  Use brew to install basic tools.
-  -  Write into terminal window: ```brew install git svn mercurial```.
+  -  Write into terminal window:   ```brew install git svn mercurial  ```.
   -  (optional) brew cask install atom.
 2.  Install XCode.
-  -  Install Command Line Tools by writing this into the terminal: ```xcode-select --install```.
+  -  Install Command Line Tools by writing this into the terminal:   ```xcode-select --install  ```.
 3.  Clone repository
-  -  In Terminal, make a working directory (can also be on cloud) and then move into the directory using: ```cd <YourProjFolder>```.
-  -  from in the directory run the git clone command ```git clone <url>```
+  -  In Terminal, make a working directory (can also be on cloud) and then move into the directory using:   ```cd <YourProjFolder>  ```.
+  -  from in the directory run the git clone command   ```git clone <url>  ```
 4.  setup
-  -  using `cd` go to the directory location: ```splashkit/coresdk/external```
-  -  Run setup.sh with  ```./setup.sh```
-  -  Go to the ```coresdk/project``` folder and open in XCode.
+  -  using `cd` go to the directory location:   ```splashkit/coresdk/external  ```
+  -  Run setup.sh with    ```./setup.sh  ```
+  -  Go to the   ```coresdk/project  ``` folder and open in XCode.
   -  Build and Run from in XCode.  
 
 ### Windows
@@ -40,68 +40,68 @@ If you are reading this then you have probably already found the Splashkit-core 
 2. Install [MSYS2](https://www.msys2.org/) subsystem and follow fairly self-explanatory installer instructions &ndash; use defaults if unsure, **DO NOT INSTALL TO DIRECTORY WITH SPACES!**
 3. Install core Splashkit SDK
     - Go into MSYS2 terminal emulator and install [Git](https://git-scm.com/) over MSYS2 subsystem by typing :
-    ```
+      ```
     pacman -S git --noconfirm --disable-download-timeout
-    ```
+      ```
     - Now clone and install Splashkit via install-scripts:
-    ```
+      ```
     bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)
-    ```
+      ```
     - Restart terminal, type
-    ```
+      ```
     skm
-    ```
+      ```
     in terminal after restarting to verify successful install.
 4. Install [VSCode](https://code.visualstudio.com/).
 5. Install language tools (compilers / libs):
     - For C#, install the DotNet core sdk.
     - For C++, install GNU Compiler Collection (GCC) - g++ and clang++ in MSYS2.
       - Run the following command in terminal:
-      ```
+        ```
       pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb
-      ```
+        ```
       - Do not run compiler from main MSYS2 MSYS terminal, instead run from MSYS2 MinGW32 or MinGW64 terminals.
 6. Install  remaining tools to build Splashkit:
     - Install cmake:
-    ```
+      ```
     pacman -S mingw-w64-x86_64-cmake
-    ```
+      ```
     - install make:
-    ```
+      ```
     pacman -S mingw-w64-x86_64-make
-    ```
+      ```
 7. Build the test project:
     - Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type:
-    ```
+      ```
     cd projects/cmake
-   ```
-    ```
+     ```
+      ```
     cmake -G "Unix Makefiles" .
-    ```
-    ```
+      ```
+      ```
     make
-    ```
+      ```
     - Note: if the above does not work, try using the actual unix make and cmake installations, rather than the MinGw-specific ones; but do not try a combination of both. Remove packages with
-    ```
+      ```
     pacman -Rs <package>
-    ```
+      ```
     and
-    ```
+      ```
     pacman -S cmake make
-    ```
+      ```
 8. Run the test program by executing
-```
+  ```
 cd ../../bin
-```
-```
+  ```
+  ```
 ./sktest
-```
+  ```
 9. Add features to code in
-```
+  ```
 ./coresdk
-```
+  ```
 10. Add test code into
-```
+  ```
 coresdk/src/test
-```
+  ```
 Now you should be good to go.

--- a/setting-up-splashkit-dev.md
+++ b/setting-up-splashkit-dev.md
@@ -1,16 +1,18 @@
-# SplashKit
-
+# SplashKit Development
 
 ## Building SplashKit
 
 Requires
-- clang Compiler
-- git
-- mac
-  - XCode
-- Windows
-  - MSys2
+- Base-level reqs
+  - clang Compiler
+  - git
+- OS-specific reqs
+  - mac
+    - XCode
+  - Windows
+    - MSYS2
 
+If you are reading this then you have probably already found the Splashkit-core Git repo, at least via the web client interface.  To Follow these instructions you will need to [fork and clone](https://guides.github.com/activities/forking/) the Splashkit core SDK.
 
 ##  Steps for setting up
 ### Mac
@@ -31,7 +33,29 @@ Requires
   -  Go to the ```coresdk/project``` folder and open in XCode.
   -  Build and Run from in XCode.  
 
-
 ### Windows
-
-1. MSys2
+1. If an issue, potentially consider **temporarily** disabling antivirus software.
+2. Install [MSYS2](https://www.msys2.org/) subsystem and follow fairly self-explanatory installer instructions - use defaults if unsure, **DO NOT INSTALL TO DIRECTORY WITH SPACES!**
+3. Install core Splashkit SDK
+  - Go into MSYS2 terminal emulator and install [Git](https://git-scm.com/) over MSYS2 subsystem by typing : ```pacman -S git --noconfirm --disable-download-timeout```
+    - Now clone and install Splashkit via install-scripts: ```bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)```
+  - Restart terminal ensuring success, type ```skm``` in terminal after restarting to check.
+4. Install [VSCode](https://code.visualstudio.com/).
+5. Install language tools (compilers / libs):
+  - For C#, install the DotNet core sdk.
+  - For C++, install GNU Compiler Collection (GCC) - g++ and clang++ in MSYS2.
+    - Run the following command in terminal: ```pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb```
+  - Do not run compiler from main MSYS2 MSYS terminal, instead run from MSYS2 MinGw32 or MinGw64 terminals.
+6. Install  remaining tools to build Splashkit:
+  - Install cmake: ```pacman -S mingw-w64-x86_64-cmake```
+  - install make: ```pacman -S mingw-w64-x86_64-make```
+7. Build the test project:
+  - Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type:```
+cd projects/cmake
+cmake .
+make```
+8. Run the test program by executing```
+cd ../../bin
+./sktest```
+9. Add features to code in ```./coresdk```
+10. Add test code into ```coresdk/src/test```

--- a/setting-up-splashkit-dev.md
+++ b/setting-up-splashkit-dev.md
@@ -40,43 +40,21 @@ If you are reading this then you have probably already found the Splashkit-core 
 2. Install [MSYS2](https://www.msys2.org/) subsystem and follow fairly self-explanatory installer instructions &ndash; use defaults if unsure, **DO NOT INSTALL TO DIRECTORY WITH SPACES!**
 3. Install core Splashkit SDK
     - Go into MSYS2 terminal emulator and install [Git](https://git-scm.com/) over MSYS2 subsystem by typing : ```pacman -S git --noconfirm --disable-download-timeout```
-    - Now clone and install Splashkit via install-scripts:
-
-```bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)```
-    - Restart terminal, type
-
-```skm```
-
-in terminal after restarting to verify successful install.
+    - Now clone and install Splashkit via install-scripts: ```bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)```
+    - Restart terminal, type ```skm``` in terminal after restarting to verify successful install.
 4. Install [VSCode](https://code.visualstudio.com/).
 5. Install language tools (compilers / libs):
     - For C#, install the DotNet core sdk.
     - For C++, install GNU Compiler Collection (GCC) - g++ and clang++ in MSYS2.
-      - Run the following command in terminal:
-  
-  ```pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb```
-      - Do not run compiler from main MSYS2 MSYS terminal, instead run from MSYS2 MinGw32 or MinGw64 terminals.
+      - Run the following command in terminal: ```pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb```
+      - Do not run compiler from main MSYS2 MSYS terminal, instead run from MSYS2 MinGW32 or MinGW64 terminals.
 6. Install  remaining tools to build Splashkit:
-    - Install cmake:
-
-```pacman -S mingw-w64-x86_64-cmake```8
-    - install make:
-
-```pacman -S mingw-w64-x86_64-make```
+    - Install cmake: ```pacman -S mingw-w64-x86_64-cmake```8
+    - install make: ```pacman -S mingw-w64-x86_64-make```
 7. Build the test project:
-    - Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type:
-
-```cd projects/cmake```
-
-```cmake -G "Unix Makefiles" .```
-
-```make```
-    - Note: if the above does not work, try using the actual unix make and cmake installations, rather than the MinGw-specific ones; but do not try a combination of both. Remove packages with ```pacman -Rs <pacmage>``` and ```pacman -S cmake make```
-8. Run the test program by executing
-
-```cd ../../bin```
-
-```./sktest```
+    - Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type: ```cd projects/cmake``` ```cmake -G "Unix Makefiles" .``` ```make```
+    - Note: if the above does not work, try using the actual unix make and cmake installations, rather than the MinGw-specific ones; but do not try a combination of both. Remove packages with ```pacman -Rs <package>``` and ```pacman -S cmake make```
+8. Run the test program by executing ```cd ../../bin``` ```./sktest```
 9. Add features to code in ```./coresdk```
 10. Add test code into ```coresdk/src/test```
 Now you should be good to go.

--- a/setting-up-splashkit-dev.md
+++ b/setting-up-splashkit-dev.md
@@ -36,9 +36,9 @@ If you are reading this then you have probably already found the Splashkit-core 
   -  Build and Run from in XCode.  
 
 ### Windows
-1. If an issue, potentially consider **temporarily** disabling antivirus software.
-2. Install [MSYS2](https://www.msys2.org/) subsystem and follow fairly self-explanatory installer instructions &ndash; use defaults if unsure, **DO NOT INSTALL TO DIRECTORY WITH SPACES!**
-3. Install core Splashkit SDK
+* If an issue, potentially consider **temporarily** disabling antivirus software.
+* Install [MSYS2](https://www.msys2.org/) subsystem and follow fairly self-explanatory installer instructions &ndash; use defaults if unsure, **DO NOT INSTALL TO DIRECTORY WITH SPACES!**
+* Install core Splashkit SDK
     - Go into MSYS2 terminal emulator and install [Git](https://git-scm.com/) over MSYS2 subsystem by typing :
       ```
     pacman -S git --noconfirm --disable-download-timeout
@@ -52,8 +52,8 @@ If you are reading this then you have probably already found the Splashkit-core 
     skm
       ```
     in terminal after restarting to verify successful install.
-4. Install [VSCode](https://code.visualstudio.com/).
-5. Install language tools (compilers / libs):
+* Install [VSCode](https://code.visualstudio.com/).
+* Install language tools (compilers / libs):
     - For C#, install the DotNet core sdk.
     - For C++, install GNU Compiler Collection (GCC) - g++ and clang++ in MSYS2.
       - Run the following command in terminal:
@@ -61,7 +61,7 @@ If you are reading this then you have probably already found the Splashkit-core 
       pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb
         ```
       - Do not run compiler from main MSYS2 MSYS terminal, instead run from MSYS2 MinGW32 or MinGW64 terminals.
-6. Install  remaining tools to build Splashkit:
+* Install  remaining tools to build Splashkit:
     - Install cmake:
       ```
     pacman -S mingw-w64-x86_64-cmake
@@ -70,7 +70,7 @@ If you are reading this then you have probably already found the Splashkit-core 
       ```
     pacman -S mingw-w64-x86_64-make
       ```
-7. Build the test project:
+* Build the test project:
     - Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type:
       ```
     cd projects/cmake
@@ -89,18 +89,18 @@ If you are reading this then you have probably already found the Splashkit-core 
       ```
     pacman -S cmake make
       ```
-8. Run the test program by executing
+* Run the test program by executing
   ```
 cd ../../bin
   ```
   ```
 ./sktest
   ```
-9. Add features to code in
+* Add features to code in
   ```
 ./coresdk
   ```
-10. Add test code into
+* Add test code into
   ```
 coresdk/src/test
   ```

--- a/setting-up-splashkit-dev.md
+++ b/setting-up-splashkit-dev.md
@@ -90,18 +90,18 @@ If you are reading this then you have probably already found the Splashkit-core 
     pacman -S cmake make
       ```
 * Run the test program by executing
-  ```
-cd ../../bin
-  ```
-  ```
-./sktest
-  ```
+    ```
+    cd ../../bin
+    ```
+    ```
+    ./sktest
+      ```
 * Add features to code in
-  ```
-./coresdk
-  ```
+    ```
+    ./coresdk
+    ```
 * Add test code into
-  ```
-coresdk/src/test
-  ```
+    ```
+    coresdk/src/test
+    ```
 Now you should be good to go.

--- a/setting-up-splashkit-dev.md
+++ b/setting-up-splashkit-dev.md
@@ -41,41 +41,41 @@ If you are reading this then you have probably already found the Splashkit-core 
 3. Install core Splashkit SDK
     - Go into MSYS2 terminal emulator and install [Git](https://git-scm.com/) over MSYS2 subsystem by typing : ```pacman -S git --noconfirm --disable-download-timeout```
     - Now clone and install Splashkit via install-scripts:
-<br>
+
 ```bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)```
     - Restart terminal, type
-<br>
+
 ```skm```
-<br>
+
 in terminal after restarting to verify successful install.
 4. Install [VSCode](https://code.visualstudio.com/).
 5. Install language tools (compilers / libs):
     - For C#, install the DotNet core sdk.
     - For C++, install GNU Compiler Collection (GCC) - g++ and clang++ in MSYS2.
       - Run the following command in terminal:
-  <br>
+  
   ```pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb```
       - Do not run compiler from main MSYS2 MSYS terminal, instead run from MSYS2 MinGw32 or MinGw64 terminals.
 6. Install  remaining tools to build Splashkit:
     - Install cmake:
-<br>
+
 ```pacman -S mingw-w64-x86_64-cmake```8
     - install make:
-<br>
+
 ```pacman -S mingw-w64-x86_64-make```
 7. Build the test project:
     - Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type:
-<br>
+
 ```cd projects/cmake```
-<br>
+
 ```cmake -G "Unix Makefiles" .```
-<br>
+
 ```make```
     - Note: if the above does not work, try using the actual unix make and cmake installations, rather than the MinGw-specific ones; but do not try a combination of both. Remove packages with ```pacman -Rs <pacmage>``` and ```pacman -S cmake make```
 8. Run the test program by executing
-<br>
+
 ```cd ../../bin```
-<br>
+
 ```./sktest```
 9. Add features to code in ```./coresdk```
 10. Add test code into ```coresdk/src/test```

--- a/setting-up-splashkit-dev.md
+++ b/setting-up-splashkit-dev.md
@@ -1,4 +1,6 @@
 # SplashKit Development
+<!--Original author: @ClancyLight (GitHub username), committed by Andrew Cain (GitHub @macite <macite@gmail.com>
+Modified by Nathaniel Schmidt <schmidty2244@gmail.com> (GitHub @njsch) on 04/09/2020-->
 
 ## Building SplashKit
 
@@ -24,7 +26,7 @@ If you are reading this then you have probably already found the Splashkit-core 
   -  (optional) brew cask install atom.
 2.  Install XCode.
   -  Install Command Line Tools by writing this into the terminal: ```xcode-select --install```.
-3.  Clone repositry
+3.  Clone repository
   -  In Terminal, make a working directory (can also be on cloud) and then move into the directory using: ```cd <YourProjFolder>```.
   -  from in the directory run the git clone command ```git clone <url>```
 4.  setup
@@ -34,28 +36,60 @@ If you are reading this then you have probably already found the Splashkit-core 
   -  Build and Run from in XCode.  
 
 ### Windows
-1. If an issue, potentially consider **temporarily** disabling antivirus software.
-2. Install [MSYS2](https://www.msys2.org/) subsystem and follow fairly self-explanatory installer instructions - use defaults if unsure, **DO NOT INSTALL TO DIRECTORY WITH SPACES!**
-3. Install core Splashkit SDK
-  - Go into MSYS2 terminal emulator and install [Git](https://git-scm.com/) over MSYS2 subsystem by typing : ```pacman -S git --noconfirm --disable-download-timeout```
-    - Now clone and install Splashkit via install-scripts: ```bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)```
-  - Restart terminal ensuring success, type ```skm``` in terminal after restarting to check.
-4. Install [VSCode](https://code.visualstudio.com/).
-5. Install language tools (compilers / libs):
-  - For C#, install the DotNet core sdk.
-  - For C++, install GNU Compiler Collection (GCC) - g++ and clang++ in MSYS2.
-    - Run the following command in terminal: ```pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb```
-  - Do not run compiler from main MSYS2 MSYS terminal, instead run from MSYS2 MinGw32 or MinGw64 terminals.
-6. Install  remaining tools to build Splashkit:
-  - Install cmake: ```pacman -S mingw-w64-x86_64-cmake```
-  - install make: ```pacman -S mingw-w64-x86_64-make```
-7. Build the test project:
-  - Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type:```
-cd projects/cmake
-cmake .
-make```
-8. Run the test program by executing```
-cd ../../bin
-./sktest```
-9. Add features to code in ```./coresdk```
-10. Add test code into ```coresdk/src/test```
+<ol>
+<li>If an issue, potentially consider **temporarily** disabling antivirus software.</li>
+<li>Install [MSYS2](https://www.msys2.org/) subsystem and follow fairly self-explanatory installer instructions &ndash; use defaults if unsure, **DO NOT INSTALL TO DIRECTORY WITH SPACES!**</li>
+<li>Install core Splashkit SDK</li>
+<ul>
+<li>Go into MSYS2 terminal emulator and install [Git](https://git-scm.com/) over MSYS2 subsystem by typing : ```pacman -S git --noconfirm --disable-download-timeout```</li>
+<li>Now clone and install Splashkit via install-scripts:
+<b>
+```bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)```</li>
+<li>Restart terminal, type
+<b>
+```skm```
+<b>
+in terminal after restarting to verify successful install.</li>
+</ul>
+<li>Install [VSCode](https://code.visualstudio.com/).</li>
+<li>Install language tools (compilers / libs):</li>
+<ul>
+<li> For C#, install the DotNet core sdk.</li>
+<li>For C++, install GNU Compiler Collection (GCC) - g++ and clang++ in MSYS2.</li>
+<ul>
+<li>Run the following command in terminal:
+  <b>
+  ```pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb```</li>
+<li>Do not run compiler from main MSYS2 MSYS terminal, instead run from MSYS2 MinGw32 or MinGw64 terminals.</li>
+</ul>
+</ul>
+<li>Install  remaining tools to build Splashkit:</li>
+<ul>
+<li>Install cmake:
+<b>
+```pacman -S mingw-w64-x86_64-cmake```8</li>
+<li>install make:
+<b>
+```pacman -S mingw-w64-x86_64-make```</li>
+</ul>
+<li>Build the test project:</li>
+<ul>
+<li>Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type:
+<b>
+```cd projects/cmake```
+<b>
+```cmake -G "Unix Makefiles" .```
+<b>
+```make```</li>
+<li>Note: if the above does not work, try using the actual unix make and cmake installations, rather than the MinGw-specific ones; but do not try a combination of both. Remove packages with ```pacman -Rs <pacmage>``` and ```pacman -S cmake make```</li>
+</ul>
+<li>Run the test program by executing
+<b>
+```cd ../../bin```
+<b>
+```./sktest```</li>
+</ul>
+<li>Add features to code in ```./coresdk```</li>
+<li>Add test code into ```coresdk/src/test```</li>
+</ol>
+Now you should be good to go.

--- a/setting-up-splashkit-dev.md
+++ b/setting-up-splashkit-dev.md
@@ -39,22 +39,62 @@ If you are reading this then you have probably already found the Splashkit-core 
 1. If an issue, potentially consider **temporarily** disabling antivirus software.
 2. Install [MSYS2](https://www.msys2.org/) subsystem and follow fairly self-explanatory installer instructions &ndash; use defaults if unsure, **DO NOT INSTALL TO DIRECTORY WITH SPACES!**
 3. Install core Splashkit SDK
-    - Go into MSYS2 terminal emulator and install [Git](https://git-scm.com/) over MSYS2 subsystem by typing : ```pacman -S git --noconfirm --disable-download-timeout```
-    - Now clone and install Splashkit via install-scripts: ```bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)```
-    - Restart terminal, type ```skm``` in terminal after restarting to verify successful install.
+    - Go into MSYS2 terminal emulator and install [Git](https://git-scm.com/) over MSYS2 subsystem by typing :
+```
+pacman -S git --noconfirm --disable-download-timeout
+```
+    - Now clone and install Splashkit via install-scripts:
+```
+bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)
+```
+    - Restart terminal, type
+```
+skm
+```
+in terminal after restarting to verify successful install.
 4. Install [VSCode](https://code.visualstudio.com/).
 5. Install language tools (compilers / libs):
     - For C#, install the DotNet core sdk.
     - For C++, install GNU Compiler Collection (GCC) - g++ and clang++ in MSYS2.
-      - Run the following command in terminal: ```pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb```
+      - Run the following command in terminal:
+```
+pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb
+```
       - Do not run compiler from main MSYS2 MSYS terminal, instead run from MSYS2 MinGW32 or MinGW64 terminals.
 6. Install  remaining tools to build Splashkit:
-    - Install cmake: ```pacman -S mingw-w64-x86_64-cmake```8
-    - install make: ```pacman -S mingw-w64-x86_64-make```
+    - Install cmake:
+```
+pacman -S mingw-w64-x86_64-cmake
+```
+    - install make:
+```
+pacman -S mingw-w64-x86_64-make
+```
 7. Build the test project:
-    - Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type: ```cd projects/cmake``` ```cmake -G "Unix Makefiles" .``` ```make```
-    - Note: if the above does not work, try using the actual unix make and cmake installations, rather than the MinGw-specific ones; but do not try a combination of both. Remove packages with ```pacman -Rs <package>``` and ```pacman -S cmake make```
-8. Run the test program by executing ```cd ../../bin``` ```./sktest```
-9. Add features to code in ```./coresdk```
-10. Add test code into ```coresdk/src/test```
+    - Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type:
+```
+cd projects/cmake``` ```cmake -G "Unix Makefiles" .``` ```make
+```
+    - Note: if the above does not work, try using the actual unix make and cmake installations, rather than the MinGw-specific ones; but do not try a combination of both. Remove packages with
+```
+pacman -Rs <package>
+``` and
+```
+pacman -S cmake make
+```
+8. Run the test program by executing
+```
+cd ../../bin
+```
+```
+./sktest
+```
+9. Add features to code in
+```
+./coresdk
+```
+10. Add test code into
+```
+coresdk/src/test
+```
 Now you should be good to go.

--- a/setting-up-splashkit-dev.md
+++ b/setting-up-splashkit-dev.md
@@ -36,60 +36,47 @@ If you are reading this then you have probably already found the Splashkit-core 
   -  Build and Run from in XCode.  
 
 ### Windows
-<ol>
-<li>If an issue, potentially consider **temporarily** disabling antivirus software.</li>
-<li>Install [MSYS2](https://www.msys2.org/) subsystem and follow fairly self-explanatory installer instructions &ndash; use defaults if unsure, **DO NOT INSTALL TO DIRECTORY WITH SPACES!**</li>
-<li>Install core Splashkit SDK</li>
-<ul>
-<li>Go into MSYS2 terminal emulator and install [Git](https://git-scm.com/) over MSYS2 subsystem by typing : ```pacman -S git --noconfirm --disable-download-timeout```</li>
-<li>Now clone and install Splashkit via install-scripts:
-<b>
-```bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)```</li>
-<li>Restart terminal, type
-<b>
+1. If an issue, potentially consider **temporarily** disabling antivirus software.
+2. Install [MSYS2](https://www.msys2.org/) subsystem and follow fairly self-explanatory installer instructions &ndash; use defaults if unsure, **DO NOT INSTALL TO DIRECTORY WITH SPACES!**
+3. Install core Splashkit SDK
+    - Go into MSYS2 terminal emulator and install [Git](https://git-scm.com/) over MSYS2 subsystem by typing : ```pacman -S git --noconfirm --disable-download-timeout```
+    - Now clone and install Splashkit via install-scripts:
+<br>
+```bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)```
+    - Restart terminal, type
+<br>
 ```skm```
-<b>
-in terminal after restarting to verify successful install.</li>
-</ul>
-<li>Install [VSCode](https://code.visualstudio.com/).</li>
-<li>Install language tools (compilers / libs):</li>
-<ul>
-<li> For C#, install the DotNet core sdk.</li>
-<li>For C++, install GNU Compiler Collection (GCC) - g++ and clang++ in MSYS2.</li>
-<ul>
-<li>Run the following command in terminal:
-  <b>
-  ```pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb```</li>
-<li>Do not run compiler from main MSYS2 MSYS terminal, instead run from MSYS2 MinGw32 or MinGw64 terminals.</li>
-</ul>
-</ul>
-<li>Install  remaining tools to build Splashkit:</li>
-<ul>
-<li>Install cmake:
-<b>
-```pacman -S mingw-w64-x86_64-cmake```8</li>
-<li>install make:
-<b>
-```pacman -S mingw-w64-x86_64-make```</li>
-</ul>
-<li>Build the test project:</li>
-<ul>
-<li>Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type:
-<b>
+<br>
+in terminal after restarting to verify successful install.
+4. Install [VSCode](https://code.visualstudio.com/).
+5. Install language tools (compilers / libs):
+    - For C#, install the DotNet core sdk.
+    - For C++, install GNU Compiler Collection (GCC) - g++ and clang++ in MSYS2.
+      - Run the following command in terminal:
+  <br>
+  ```pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb```
+      - Do not run compiler from main MSYS2 MSYS terminal, instead run from MSYS2 MinGw32 or MinGw64 terminals.
+6. Install  remaining tools to build Splashkit:
+    - Install cmake:
+<br>
+```pacman -S mingw-w64-x86_64-cmake```8
+    - install make:
+<br>
+```pacman -S mingw-w64-x86_64-make```
+7. Build the test project:
+    - Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type:
+<br>
 ```cd projects/cmake```
-<b>
+<br>
 ```cmake -G "Unix Makefiles" .```
-<b>
-```make```</li>
-<li>Note: if the above does not work, try using the actual unix make and cmake installations, rather than the MinGw-specific ones; but do not try a combination of both. Remove packages with ```pacman -Rs <pacmage>``` and ```pacman -S cmake make```</li>
-</ul>
-<li>Run the test program by executing
-<b>
+<br>
+```make```
+    - Note: if the above does not work, try using the actual unix make and cmake installations, rather than the MinGw-specific ones; but do not try a combination of both. Remove packages with ```pacman -Rs <pacmage>``` and ```pacman -S cmake make```
+8. Run the test program by executing
+<br>
 ```cd ../../bin```
-<b>
-```./sktest```</li>
-</ul>
-<li>Add features to code in ```./coresdk```</li>
-<li>Add test code into ```coresdk/src/test```</li>
-</ol>
+<br>
+```./sktest```
+9. Add features to code in ```./coresdk```
+10. Add test code into ```coresdk/src/test```
 Now you should be good to go.

--- a/setting-up-splashkit-dev.md
+++ b/setting-up-splashkit-dev.md
@@ -41,16 +41,16 @@ If you are reading this then you have probably already found the Splashkit-core 
 3. Install core Splashkit SDK
     - Go into MSYS2 terminal emulator and install [Git](https://git-scm.com/) over MSYS2 subsystem by typing :
     ```
-pacman -S git --noconfirm --disable-download-timeout
-```
+    pacman -S git --noconfirm --disable-download-timeout
+    ```
     - Now clone and install Splashkit via install-scripts:
     ```
-bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)
-```
+    bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)
+    ```
     - Restart terminal, type
     ```
-skm
-```
+    skm
+    ```
     in terminal after restarting to verify successful install.
 4. Install [VSCode](https://code.visualstudio.com/).
 5. Install language tools (compilers / libs):
@@ -58,37 +58,37 @@ skm
     - For C++, install GNU Compiler Collection (GCC) - g++ and clang++ in MSYS2.
       - Run the following command in terminal:
       ```
-pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb
-```
+      pacman --disable-download-timeout -S mingw-w64-{x86_64,i686}-gcc mingw-w64-{i686,x86_64}-gdb
+      ```
       - Do not run compiler from main MSYS2 MSYS terminal, instead run from MSYS2 MinGW32 or MinGW64 terminals.
 6. Install  remaining tools to build Splashkit:
     - Install cmake:
     ```
-pacman -S mingw-w64-x86_64-cmake
-```
+    pacman -S mingw-w64-x86_64-cmake
+    ```
     - install make:
     ```
-pacman -S mingw-w64-x86_64-make
-```
+    pacman -S mingw-w64-x86_64-make
+    ```
 7. Build the test project:
     - Go into the cloned directory of your Splashkit fork, open a MinGw-W64 MSYS2 shell and type:
     ```
-cd projects/cmake
-```
+    cd projects/cmake
+   ```
     ```
-cmake -G "Unix Makefiles" .
-```
+    cmake -G "Unix Makefiles" .
     ```
-make
-```
+    ```
+    make
+    ```
     - Note: if the above does not work, try using the actual unix make and cmake installations, rather than the MinGw-specific ones; but do not try a combination of both. Remove packages with
     ```
-pacman -Rs <package>
-```
+    pacman -Rs <package>
+    ```
     and
     ```
-pacman -S cmake make
-```
+    pacman -S cmake make
+    ```
 8. Run the test program by executing
 ```
 cd ../../bin


### PR DESCRIPTION
* Updated: ./setting-up-splashkit-dev.md to include much more detailed instructions on how to install on Windows.  Should now clear up a lot of previous ambiguity.