### PR TITLE
Fix send response suffix

### DIFF
--- a/coresdk/src/coresdk/web_server.cpp
+++ b/coresdk/src/coresdk/web_server.cpp
@@ -78,11 +78,6 @@ namespace splashkit_lib
         r->control.release();
     }
 
-    void send_response(http_request r, const string &message)
-    {
-        send_response(r, HTTP_STATUS_OK, message, "text/plain", {});
-    }
-
     void send_response(http_request r, http_status_code code, const string &message, const string &content_type, const vector<string> &headers)
     {
         sk_http_response resp;
@@ -105,6 +100,11 @@ namespace splashkit_lib
     void send_response(http_request r, http_status_code code, const string &message, const string &content_type)
     {
       send_response(r, code, message, content_type, {});
+    }
+
+    void send_response(http_request r, const string &message)
+    {
+        send_response(r, HTTP_STATUS_OK, message, "text/plain");
     }
 
     void send_response(http_request r, http_status_code code, const string &message)

--- a/coresdk/src/coresdk/web_server.h
+++ b/coresdk/src/coresdk/web_server.h
@@ -132,7 +132,7 @@ namespace splashkit_lib
      * @attribute self  r
      * @attribute method send_response
      *
-     * @attribute suffix  with_status_and_content_type
+     * @attribute suffix  with_status_and_content_type_and_headers
      */
     void send_response(http_request r, http_status_code code, const string &message, const string &content_type, const vector<string> &headers);
 


### PR DESCRIPTION
Fix the suffix attribute for `send_response` to avoid conflicts.