### PR TITLE
NEW Add box2d integration

### DIFF
--- a/coresdk/src/coresdk/physics.cpp
+++ b/coresdk/src/coresdk/physics.cpp
@@ -7,3 +7,71 @@
 //
 
 #include "physics.h"
+#include <algorithm>
+#define M_PI 3.14159265358979323846264338327950288
+
+using namespace splashkit_lib;
+Box2DContext::Box2DContext()
+{
+    options = option_defaults();
+    options.scale_x = SCALE_X;
+    options.scale_y = SCALE_Y;
+    default_body_definition.position.Set(0, 0);
+}
+std::pair<sprite, b2Body*>* Box2DContext::add_sprite_to_world(sprite s, const b2BodyDef& bodyDef)
+{
+    b2BodyDef definition{bodyDef};
+    definition.position.Set(
+        (sprite_position(s).x + (sprite_width(s)/2)) / options.scale_x,
+        (sprite_position(s).y + (sprite_height(s)/2)) / options.scale_y
+    );
+    definition.angle = sprite_rotation(s) * M_PI / 180.0f;
+	b2Body* body = world.CreateBody(&definition);
+
+	b2PolygonShape dynamicBox;
+	dynamicBox.SetAsBox(sprite_width(s)/options.scale_y/2, sprite_height(s)/options.scale_y/2);
+	b2FixtureDef fixtureDef;
+	fixtureDef.shape = &dynamicBox;
+	fixtureDef.density = 1.0f;
+	fixtureDef.friction = 0.3f;
+	body->CreateFixture(&fixtureDef);
+    auto pair = new std::pair<sprite, b2Body*>{s, body};
+    sprites_in_the_world.push_back(pair);
+    return pair;
+}
+auto Box2DContext::find_sprite(sprite sprite){
+    return std::find_if(sprites_in_the_world.begin(), sprites_in_the_world.end(),
+    [&](auto& valueTest){
+        return sprite == valueTest->first;
+    });
+
+}
+sprite Box2DContext::remove_sprite_from_world(sprite sprite){
+    sprites_in_the_world.erase(find_sprite(sprite));
+    return sprite;
+}
+
+const std::pair<sprite, b2Body *>* Box2DContext::find(sprite sprite){
+    return *(find_sprite(sprite)).base();
+}
+sprite Box2DContext::remove_sprite_from_world(int index){
+    auto sprite = sprites_in_the_world.at(index);
+    sprites_in_the_world.erase(sprites_in_the_world.begin() + index);
+
+    return sprite->first;
+}
+
+void Box2DContext::step(){
+    this->world.Step(RESOLUTION, BOX2D_VELCOITY_ITERATIONS, BOX2D_POSITION_ITERATIONS);
+    for(auto spriteBodyPair : sprites_in_the_world){
+        auto sprite = spriteBodyPair->first;
+        auto body = spriteBodyPair->second;
+        auto bodyExtents = body->GetFixtureList()->GetAABB(0).GetExtents();
+
+        sprite_set_position(sprite, {(body->GetPosition().x - bodyExtents.x) * options.scale_x,
+                                     (body->GetPosition().y - bodyExtents.y) * options.scale_y});
+
+        sprite_set_rotation(sprite, body->GetAngle()*(180.0f/M_PI));
+
+    }
+}

--- a/coresdk/src/coresdk/physics.h
+++ b/coresdk/src/coresdk/physics.h
@@ -11,4 +11,69 @@
 #include "vector_2d.h"
 #include "collisions.h"
 
+#include "drawing_options.h"
+#include "sprites.h"
+#include <vector>
+#include <utility>
+
+
+#include "box2d/box2d.h"
+
+
+namespace splashkit_lib
+{
+    // Constant for gravity for box2d. It is positive because
+    // the vertical axis increases towards the bottom of the screen.
+    constexpr float GRAVITY = 9.82f;
+    constexpr float RESOLUTION = 1.0/60.0;
+    constexpr int BOX2D_VELCOITY_ITERATIONS = 6;
+    constexpr int BOX2D_POSITION_ITERATIONS = 2;
+    constexpr float SCALE_X = 100.0f;
+    constexpr float SCALE_Y = 100.0f;
+
+    /**
+     * Holds the context for interacting with the box2d library.
+     * You are expected to allocate and hold a reference to this.
+     * This will create a box2d world and keep it alive until this is
+     * destroyed
+     * 
+     * Allocating bodies into this world with sprites will cause the sprite's
+     * position and angle to be updated by this world.
+     **/
+    class Box2DContext
+    {
+    public:
+        Box2DContext();
+        /**
+         * This creates and allocates a box2d body and fixture to act in the world
+         * and keeps a reference to the sprite to be updated.
+         **/
+        std::pair<sprite, b2Body*>* add_sprite_to_world(sprite, const b2BodyDef&);
+        std::pair<sprite, b2Body*>* add_sprite_to_world(sprite s){
+            return add_sprite_to_world(s, default_body_definition);
+        }
+        void step();
+        /**
+         * Find a sprite and remove it from the world.
+         * This will also remove the box2d body.
+         */
+        sprite remove_sprite_from_world(sprite);
+        sprite remove_sprite_from_world(int);
+
+        /**
+         * Locate the sprite in the world and return the sprite, box2d body pair.
+         */
+        const std::pair<sprite, b2Body *>* find(sprite sprite);
+        auto find_sprite(sprite);
+        b2BodyDef get_default_body_definition(){
+            return default_body_definition;
+        }
+
+    private:
+        b2BodyDef default_body_definition;
+        b2World world{{0.0f, GRAVITY}};
+        drawing_options options;
+        std::vector<std::pair<sprite, b2Body*>*> sprites_in_the_world;
+    };
+} // namespace splaskit_lib
 #endif /* physics_hpp */

--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -46,13 +46,16 @@ if (APPLE)
                    -lfreetype \
                    -lcurl \
                    -lncurses \
-                   -ldl")
+                   -ldl \
+                   -lBox2D")
 # WINDOWS PROJECT FLAGS
 elseif(MSYS)
     set(LIB_FLAGS "-L${SK_LIB}/win64 \
                    -L/mingw64/lib \
                    -L/usr/lib \
-                   -lSDL2main")
+                   -lSDL2main"
+                   -lBox2D
+									 )
 # LINUX PROJECT FLAGS
 else()
     set(LIB_FLAGS "-lSDL2 \
@@ -74,7 +77,9 @@ else()
                    -lfreetype \
                    -lcurl \
                    -lncurses \
-                   -ldl")
+                   -ldl"
+                   -lBox2D
+        )
 endif()
 
 # FLAGS
@@ -109,6 +114,7 @@ include_directories("${SK_SRC}")
 include_directories("${SK_SRC}/coresdk")
 include_directories("${SK_SRC}/backend")
 include_directories("${SK_SRC}/test")
+include_directories("${SK_EXT}")
 include_directories("${SK_EXT}/civetweb/include")
 include_directories("${SK_EXT}/easyloggingpp")
 include_directories("${SK_EXT}/hash-library")


### PR DESCRIPTION
This add a simple wrapper around box2d and some functions to manage the frame of reference mapping between box2d and splashkit. I have no idea how to expose to the other languages though.

This is missing the libraries to distribute and will need an extra commit to external for the headers.