### PR TITLE
Add /out/lib directory to gitignore, as this should not need to be added / tracked as a build-generated dir when compiling sktest.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ tools/scripts/deploy/splashkitcpp/*.a
 bin/
 logs/
 out/skm
+out/lib/


### PR DESCRIPTION
This addition would make things slightly more convenient as it would help to make things as simple as `git add --all` when making changes to the core SDK code.