### PR TITLE
Added support for sprite Vector array and Static array in center_camera_on() method

### DIFF
--- a/coresdk/src/coresdk/camera.cpp
+++ b/coresdk/src/coresdk/camera.cpp
@@ -233,7 +233,7 @@ namespace splashkit_lib
 	
 	void center_camera_on(sprite s[],int size , const vector_2d &offset)
     {
-        center_camera_on(s, offset.x, offset.y);
+        center_camera_on(s,size, offset.x, offset.y);
     }
 	
 	void center_camera_on(vector<sprite> s, const vector_2d &offset)

--- a/coresdk/src/coresdk/camera.cpp
+++ b/coresdk/src/coresdk/camera.cpp
@@ -168,28 +168,12 @@ namespace splashkit_lib
         move_camera_by(offset.x, offset.y);
     }
 
-    // void center_camera_on(sprite s, double offset_x, double offset_y)
-    // {
-    //     point_2d center = sprite_position(s);
-
-    //     double sc_x = center.x + offset_x - (screen_width() / 2);
-    //     double sc_y = center.y + offset_y - (screen_height() / 2);
-
-    //     move_camera_to(sc_x, sc_y);
-    // }
-
-    // void center_camera_on(sprite s, const vector_2d &offset)
-    // {
-    //     center_camera_on(s, offset.x, offset.y);
-    // }
-
-    // Function to center the camera on a vector array
     void center_camera_on(vector<sprite> s, double offset_x, double offset_y) {
 		
 		double sc_x{0};
 		double sc_y{0};
 		
-        for (const auto& ele : s) {
+        for (const sprite& ele : s) {
             sc_x += (sprite_position(ele).x /s.size());
             sc_y += (sprite_position(ele).y /s.size());
         }
@@ -199,16 +183,13 @@ namespace splashkit_lib
 		move_camera_to(sc_x, sc_y);
     }
     
-    // Function to center the camera on a static array, doube anyone needed this but made it anyways
     void center_camera_on(sprite s[],int size, double offset_x, double offset_y) {
-        // int size = sizeof(s)/sizeof(s[0]);
 		double sc_x{0};
 		double sc_y{0};
         
         for (int i = 0; i < size; ++i) {
             sc_x += (sprite_position(s[i]).x /size);
             sc_y += (sprite_position(s[i]).y /size);
-            
         }
 		
 		sc_x = sc_x + offset_x - (screen_width() / 2);
@@ -216,7 +197,6 @@ namespace splashkit_lib
 		move_camera_to(sc_x, sc_y);
     }
 
-    // Function to center the camera on a single sprite
     void center_camera_on(sprite s, double offset_x, double offset_y) {
 
         point_2d center = sprite_position(s);

--- a/coresdk/src/coresdk/camera.cpp
+++ b/coresdk/src/coresdk/camera.cpp
@@ -170,31 +170,31 @@ namespace splashkit_lib
 
     void center_camera_on(vector<sprite> s, double offset_x, double offset_y) {
 		
-		double sc_x{0};
-		double sc_y{0};
+        double sc_x{0};
+        double sc_y{0};
 		
         for (const sprite& ele : s) {
             sc_x += (sprite_position(ele).x /s.size());
             sc_y += (sprite_position(ele).y /s.size());
         }
 		
-		sc_x = sc_x + offset_x - (screen_width() / 2);
-		sc_y = sc_y + offset_y - (screen_height() / 2);
-		move_camera_to(sc_x, sc_y);
+        sc_x = sc_x + offset_x - (screen_width() / 2);
+        sc_y = sc_y + offset_y - (screen_height() / 2);
+        move_camera_to(sc_x, sc_y);
     }
     
     void center_camera_on(sprite s[],int size, double offset_x, double offset_y) {
-		double sc_x{0};
-		double sc_y{0};
+        double sc_x{0};
+        double sc_y{0};
         
         for (int i = 0; i < size; ++i) {
             sc_x += (sprite_position(s[i]).x /size);
             sc_y += (sprite_position(s[i]).y /size);
         }
 		
-		sc_x = sc_x + offset_x - (screen_width() / 2);
-		sc_y = sc_y + offset_y - (screen_height() / 2);
-		move_camera_to(sc_x, sc_y);
+        sc_x = sc_x + offset_x - (screen_width() / 2);
+        sc_y = sc_y + offset_y - (screen_height() / 2);
+        move_camera_to(sc_x, sc_y);
     }
 
     void center_camera_on(sprite s, double offset_x, double offset_y) {

--- a/coresdk/src/coresdk/camera.cpp
+++ b/coresdk/src/coresdk/camera.cpp
@@ -184,7 +184,7 @@ namespace splashkit_lib
     // }
 
     // Function to center the camera on a vector array
-    void center_camera_on(vector<sprite>& s, double offset_x, double offset_y) {
+    void center_camera_on(vector<sprite> s, double offset_x, double offset_y) {
 		
 		double sc_x{0};
 		double sc_y{0};
@@ -227,6 +227,16 @@ namespace splashkit_lib
     }
 
     void center_camera_on(sprite s, const vector_2d &offset)
+    {
+        center_camera_on(s, offset.x, offset.y);
+    }
+	
+	void center_camera_on(sprite s[],int size , const vector_2d &offset)
+    {
+        center_camera_on(s, offset.x, offset.y);
+    }
+	
+	void center_camera_on(vector<sprite> s, const vector_2d &offset)
     {
         center_camera_on(s, offset.x, offset.y);
     }

--- a/coresdk/src/coresdk/camera.cpp
+++ b/coresdk/src/coresdk/camera.cpp
@@ -168,12 +168,60 @@ namespace splashkit_lib
         move_camera_by(offset.x, offset.y);
     }
 
-    void center_camera_on(sprite s, double offset_x, double offset_y)
-    {
-        point_2d center = sprite_position(s);
+    // void center_camera_on(sprite s, double offset_x, double offset_y)
+    // {
+    //     point_2d center = sprite_position(s);
 
-        double sc_x = center.x + offset_x - (screen_width() / 2);
-        double sc_y = center.y + offset_y - (screen_height() / 2);
+    //     double sc_x = center.x + offset_x - (screen_width() / 2);
+    //     double sc_y = center.y + offset_y - (screen_height() / 2);
+
+    //     move_camera_to(sc_x, sc_y);
+    // }
+
+    // void center_camera_on(sprite s, const vector_2d &offset)
+    // {
+    //     center_camera_on(s, offset.x, offset.y);
+    // }
+
+    // Function to center the camera on a vector array
+    void center_camera_on(vector<sprite>& s, double offset_x, double offset_y) {
+		
+		double sc_x{0};
+		double sc_y{0};
+		
+        for (const auto& ele : s) {
+            sc_x += (sprite_position(ele).x /s.size());
+            sc_y += (sprite_position(ele).y /s.size());
+        }
+		
+		sc_x = sc_x + offset_x - (screen_width() / 2);
+		sc_y = sc_y + offset_y - (screen_height() / 2);
+		move_camera_to(sc_x, sc_y);
+    }
+    
+    // Function to center the camera on a static array, doube anyone needed this but made it anyways
+    void center_camera_on(sprite s[],int size, double offset_x, double offset_y) {
+        // int size = sizeof(s)/sizeof(s[0]);
+		double sc_x{0};
+		double sc_y{0};
+        
+        for (int i = 0; i < size; ++i) {
+            sc_x += (sprite_position(s[i]).x /size);
+            sc_y += (sprite_position(s[i]).y /size);
+            
+        }
+		
+		sc_x = sc_x + offset_x - (screen_width() / 2);
+		sc_y = sc_y + offset_y - (screen_height() / 2);
+		move_camera_to(sc_x, sc_y);
+    }
+
+    // Function to center the camera on a single sprite
+    void center_camera_on(sprite s, double offset_x, double offset_y) {
+
+        point_2d center = sprite_position(s);
+        double sc_x = sprite_position(s).x + offset_x - (screen_width() / 2);
+        double sc_y = sprite_position(s).y + offset_y - (screen_height() / 2);
 
         move_camera_to(sc_x, sc_y);
     }

--- a/coresdk/src/coresdk/camera.h
+++ b/coresdk/src/coresdk/camera.h
@@ -353,6 +353,27 @@ namespace splashkit_lib
 	 *                 position the sprites offset from the center of the screen.
 	 */
 	void center_camera_on(sprite s[],int size , double offset_x, double offset_y);
+	/**
+	 * Set the camera view to be centered over an array of sprites. The offset
+	 * vector allows you to move the sprites from the direct center of the screen.
+	 *
+	 * @param s        An array of sprites to track.
+	 * @param size     The size of the sprite array.
+	 * @param offset   The amount to offset the camera, allowing you to position
+	 *                 the sprites away from the center of the screen.
+	 */
+	void center_camera_on(sprite s[], int size, const vector_2d &offset);
+
+	/**
+	 * Set the camera view to be centered over a vector of sprites. The offset
+	 * vector allows you to move the sprites from the direct center of the screen.
+	 *
+	 * @param s        A vector of sprites to track.
+	 * @param offset   The amount to offset the camera, allowing you to position
+	 *                 the sprites away from the center of the screen.
+	 */
+	void center_camera_on(vector<sprite> s, const vector_2d &offset);
+
 
 #endif /* camera_hpp */
 }

--- a/coresdk/src/coresdk/camera.h
+++ b/coresdk/src/coresdk/camera.h
@@ -376,4 +376,3 @@ namespace splashkit_lib
 
 
 #endif /* camera_hpp */
-}

--- a/coresdk/src/coresdk/camera.h
+++ b/coresdk/src/coresdk/camera.h
@@ -376,3 +376,4 @@ namespace splashkit_lib
 
 
 #endif /* camera_hpp */
+}

--- a/coresdk/src/coresdk/camera.h
+++ b/coresdk/src/coresdk/camera.h
@@ -253,7 +253,7 @@ namespace splashkit_lib
     bool point_in_window(window wind, const point_2d &pt);
 
 
-    
+
     //---------------------------------------------------------------------------
     // Camera movement
     //---------------------------------------------------------------------------
@@ -318,19 +318,6 @@ namespace splashkit_lib
     void center_camera_on(sprite s, double offset_x, double offset_y);
 
     /**
-     * Set the camera view to be centered over the specific sprite. The offset
-     * vector allows you to move the sprite from the direct center of the screen.
-     *
-     * @param s        The sprite to track.
-     * @param offset   The amount to offset the camera, allowing you to position
-     *                 the sprite away from the center of the screen.
-     *
-     * @attribute suffix    vector
-     * @attribute method center_on
-     */
-    void center_camera_on(sprite s, const vector_2d &offset);
-
-    /**
      * Set the camera view to be centered over a list of sprites. The offset
      * vector allows you to move the sprites from the direct center of the screen.
      *
@@ -375,6 +362,19 @@ namespace splashkit_lib
      *                 the sprites away from the center of the screen.
      */
     void center_camera_on(vector<sprite> s, const vector_2d &offset);
+
+    /**
+     * Set the camera view to be centered over the specific sprite. The offset
+     * vector allows you to move the sprite from the direct center of the screen.
+     *
+     * @param s        The sprite to track.
+     * @param offset   The amount to offset the camera, allowing you to position
+     *                 the sprite away from the center of the screen.
+     *
+     * @attribute suffix    vector
+     * @attribute method center_on
+     */
+    void center_camera_on(sprite s, const vector_2d &offset);
 
 
 #endif /* camera_hpp */

--- a/coresdk/src/coresdk/camera.h
+++ b/coresdk/src/coresdk/camera.h
@@ -330,6 +330,29 @@ namespace splashkit_lib
      * @attribute method center_on
      */
     void center_camera_on(sprite s, const vector_2d &offset);
+	/**
+	 * Set the camera view to be centered over a list of sprites. The offset
+	 * vector allows you to move the sprites from the direct center of the screen.
+	 *
+	 * @param s        A vector of sprites to track.
+	 * @param offset_x An additional offset added to the camera, allowing you to
+	 *                 position the sprites offset from the center of the screen.
+	 * @param offset_y An additional offset added to the camera, allowing you to
+	 *                 position the sprites offset from the center of the screen.
+	 */
+	void center_camera_on(vector<sprite> s, double offset_x, double offset_y);
+	/**
+	 * Set the camera view to be centered over an array of sprites. The offset
+	 * vector allows you to move the sprites from the direct center of the screen.
+	 *
+	 * @param s        An array of sprites to track.
+	 * @param size     The size of the sprite array.
+	 * @param offset_x An additional offset added to the camera, allowing you to
+	 *                 position the sprites offset from the center of the screen.
+	 * @param offset_y An additional offset added to the camera, allowing you to
+	 *                 position the sprites offset from the center of the screen.
+	 */
+	void center_camera_on(sprite s[],int size , double offset_x, double offset_y);
 
 #endif /* camera_hpp */
 }

--- a/coresdk/src/coresdk/camera.h
+++ b/coresdk/src/coresdk/camera.h
@@ -253,8 +253,7 @@ namespace splashkit_lib
     bool point_in_window(window wind, const point_2d &pt);
 
 
-
-
+    
     //---------------------------------------------------------------------------
     // Camera movement
     //---------------------------------------------------------------------------
@@ -330,49 +329,52 @@ namespace splashkit_lib
      * @attribute method center_on
      */
     void center_camera_on(sprite s, const vector_2d &offset);
-	/**
-	 * Set the camera view to be centered over a list of sprites. The offset
-	 * vector allows you to move the sprites from the direct center of the screen.
-	 *
-	 * @param s        A vector of sprites to track.
-	 * @param offset_x An additional offset added to the camera, allowing you to
-	 *                 position the sprites offset from the center of the screen.
-	 * @param offset_y An additional offset added to the camera, allowing you to
-	 *                 position the sprites offset from the center of the screen.
-	 */
-	void center_camera_on(vector<sprite> s, double offset_x, double offset_y);
-	/**
-	 * Set the camera view to be centered over an array of sprites. The offset
-	 * vector allows you to move the sprites from the direct center of the screen.
-	 *
-	 * @param s        An array of sprites to track.
-	 * @param size     The size of the sprite array.
-	 * @param offset_x An additional offset added to the camera, allowing you to
-	 *                 position the sprites offset from the center of the screen.
-	 * @param offset_y An additional offset added to the camera, allowing you to
-	 *                 position the sprites offset from the center of the screen.
-	 */
-	void center_camera_on(sprite s[],int size , double offset_x, double offset_y);
-	/**
-	 * Set the camera view to be centered over an array of sprites. The offset
-	 * vector allows you to move the sprites from the direct center of the screen.
-	 *
-	 * @param s        An array of sprites to track.
-	 * @param size     The size of the sprite array.
-	 * @param offset   The amount to offset the camera, allowing you to position
-	 *                 the sprites away from the center of the screen.
-	 */
-	void center_camera_on(sprite s[], int size, const vector_2d &offset);
 
-	/**
-	 * Set the camera view to be centered over a vector of sprites. The offset
-	 * vector allows you to move the sprites from the direct center of the screen.
-	 *
-	 * @param s        A vector of sprites to track.
-	 * @param offset   The amount to offset the camera, allowing you to position
-	 *                 the sprites away from the center of the screen.
-	 */
-	void center_camera_on(vector<sprite> s, const vector_2d &offset);
+    /**
+     * Set the camera view to be centered over a list of sprites. The offset
+     * vector allows you to move the sprites from the direct center of the screen.
+     *
+     * @param s        A vector of sprites to track.
+     * @param offset_x An additional offset added to the camera, allowing you to
+     *                 position the sprites offset from the center of the screen.
+     * @param offset_y An additional offset added to the camera, allowing you to
+     *                 position the sprites offset from the center of the screen.
+     */
+    void center_camera_on(vector<sprite> s, double offset_x, double offset_y);
+
+    /**
+     * Set the camera view to be centered over an array of sprites. The offset
+     * vector allows you to move the sprites from the direct center of the screen.
+     *
+     * @param s        An array of sprites to track.
+     * @param size     The size of the sprite array.
+     * @param offset_x An additional offset added to the camera, allowing you to
+     *                 position the sprites offset from the center of the screen.
+     * @param offset_y An additional offset added to the camera, allowing you to
+     *                 position the sprites offset from the center of the screen.
+     */
+    void center_camera_on(sprite s[],int size , double offset_x, double offset_y);
+
+    /**
+     * Set the camera view to be centered over an array of sprites. The offset
+     * vector allows you to move the sprites from the direct center of the screen.
+     *
+     * @param s        An array of sprites to track.
+     * @param size     The size of the sprite array.
+     * @param offset   The amount to offset the camera, allowing you to position
+     *                 the sprites away from the center of the screen.
+     */
+    void center_camera_on(sprite s[], int size, const vector_2d &offset);
+
+    /**
+     * Set the camera view to be centered over a vector of sprites. The offset
+     * vector allows you to move the sprites from the direct center of the screen.
+     *
+     * @param s        A vector of sprites to track.
+     * @param offset   The amount to offset the camera, allowing you to position
+     *                 the sprites away from the center of the screen.
+     */
+    void center_camera_on(vector<sprite> s, const vector_2d &offset);
 
 
 #endif /* camera_hpp */

--- a/coresdk/src/test/test_camera.cpp
+++ b/coresdk/src/test/test_camera.cpp
@@ -15,27 +15,35 @@
 
 using namespace splashkit_lib;
 
+void set_keys(std::vector<key_code> keys, sprite s){
+    if ( key_down(keys[0]) ) sprite_set_dx(s, -1);
+    else if ( key_down(keys[1]) ) sprite_set_dx(s, 1);
+    else sprite_set_dx(s, 0);
+
+    if ( key_down(keys[2]) ) sprite_set_dy(s, -1);
+    else if ( key_down(keys[3]) ) sprite_set_dy(s, 1);
+    else sprite_set_dy(s, 0);
+}
+
 void run_camera_test()
 {
     window w1 = open_window("Camera Test", 600, 600);
 
     load_bitmap("ufo", "ufo.png");
-    sprite s1 = create_sprite("ufo");
-    sprite s2 = create_sprite("ufo");
-    sprite s3 = create_sprite("ufo");
+    std::vector<sprite> s_array;
+    int size = 3;
 
-    sprite_set_position(s1, screen_center());
-    sprite_set_position(s2, screen_center());
-    sprite_set_position(s3, screen_center());
+    for(int i{0};i < size ; i++){
+        s_array.push_back(create_sprite("ufo"));
+        sprite_set_position(s_array[i], screen_center());
+    }
 
-    sprite arr[3] = {s1, s2, s3};
+    std::vector<std::vector<key_code>> key_arr;
+    key_arr.push_back({LEFT_KEY, RIGHT_KEY, UP_KEY, DOWN_KEY});
+    key_arr.push_back({A_KEY, D_KEY, W_KEY, S_KEY});
+    key_arr.push_back({J_KEY, L_KEY, I_KEY, K_KEY});
 
-    std::vector<sprite> vec_arr;
-    vec_arr.push_back(s1);
-    vec_arr.push_back(s2);
-    vec_arr.push_back(s3);
-
-    sprite_set_anchor_point(s1, bitmap_cell_center(sprite_layer(s1, 0)));
+    sprite_set_anchor_point(s_array[0], bitmap_cell_center(sprite_layer(s_array[0], 0)));
 
     bool follow = true;
 
@@ -43,43 +51,18 @@ void run_camera_test()
     {
         process_events();
 
-        if ( key_down( LEFT_KEY) ) sprite_set_dx(s1, -1);
-        else if ( key_down( RIGHT_KEY) ) sprite_set_dx(s1, 1);
-        else sprite_set_dx(s1, 0);
-
-        if ( key_down( UP_KEY) ) sprite_set_dy(s1, -1);
-        else if ( key_down( DOWN_KEY) ) sprite_set_dy(s1, 1);
-        else sprite_set_dy(s1, 0);
-
-
-        if ( key_down( A_KEY) ) sprite_set_dx(s2, -1);
-        else if ( key_down( D_KEY) ) sprite_set_dx(s2, 1);
-        else sprite_set_dx(s2, 0);
-
-        if ( key_down( W_KEY) ) sprite_set_dy(s2, -1);
-        else if ( key_down( S_KEY) ) sprite_set_dy(s2, 1);
-        else sprite_set_dy(s2, 0);
-
-
-        if ( key_down( J_KEY) ) sprite_set_dx(s3, -1);
-        else if ( key_down( L_KEY) ) sprite_set_dx(s3, 1);
-        else sprite_set_dx(s3, 0);
-
-        if ( key_down( I_KEY) ) sprite_set_dy(s3, -1);
-        else if ( key_down( K_KEY) ) sprite_set_dy(s3, 1);
-        else sprite_set_dy(s3, 0);
-
         if ( key_typed(F_KEY) )
         {
-            follow = not follow;
+            follow =  !follow;
+        }
+        
+        for(int i{0};i < size ; i++){
+            set_keys(key_arr[i], s_array[i]);
+            update_sprite(s_array[i]);
         }
 
-        update_sprite(s1);
-        update_sprite(s2);
-        update_sprite(s3);
-
-        if ( follow ){
-            center_camera_on(vec_arr, 0, 0);
+        if (follow){
+            center_camera_on(s_array, 0, 0);
         }else{
             set_camera_x(0);
             set_camera_y(0);
@@ -94,9 +77,10 @@ void run_camera_test()
 
         draw_triangle(COLOR_AQUA, screen_width() / 2, 0, 0, screen_height(), screen_width(), screen_height());
 
-        draw_sprite(s1);
-        draw_sprite(s2);
-        draw_sprite(s3);
+        for(int i{0};i < size ; i++){
+            draw_sprite(s_array[i]);
+        }
+
         refresh_screen();
     }
 

--- a/coresdk/src/test/test_camera.cpp
+++ b/coresdk/src/test/test_camera.cpp
@@ -79,7 +79,7 @@ void run_camera_test()
         update_sprite(s3);
 
         if ( follow ){
-            center_camera_on(arr, 0, 0);
+            center_camera_on(vec_arr, 0, 0);
         }else{
             set_camera_x(0);
             set_camera_y(0);

--- a/coresdk/src/test/test_camera.cpp
+++ b/coresdk/src/test/test_camera.cpp
@@ -11,6 +11,7 @@
 #include "graphics.h"
 #include "camera.h"
 #include "input.h"
+#include <vector>
 
 using namespace splashkit_lib;
 
@@ -19,11 +20,22 @@ void run_camera_test()
     window w1 = open_window("Camera Test", 600, 600);
 
     load_bitmap("ufo", "ufo.png");
-    sprite s = create_sprite("ufo");
+    sprite s1 = create_sprite("ufo");
+    sprite s2 = create_sprite("ufo");
+    sprite s3 = create_sprite("ufo");
 
-    sprite_set_position(s, screen_center());
+    sprite_set_position(s1, screen_center());
+    sprite_set_position(s2, screen_center());
+    sprite_set_position(s3, screen_center());
 
-    sprite_set_anchor_point(s, bitmap_cell_center(sprite_layer(s, 0)));
+    sprite arr[3] = {s1, s2, s3};
+
+    std::vector<sprite> vec_arr;
+    vec_arr.push_back(s1);
+    vec_arr.push_back(s2);
+    vec_arr.push_back(s3);
+
+    sprite_set_anchor_point(s1, bitmap_cell_center(sprite_layer(s1, 0)));
 
     bool follow = true;
 
@@ -31,27 +43,44 @@ void run_camera_test()
     {
         process_events();
 
-        if ( key_down( LEFT_KEY) ) sprite_set_dx(s, -1);
-        else if ( key_down( RIGHT_KEY) ) sprite_set_dx(s, 1);
-        else sprite_set_dx(s, 0);
+        if ( key_down( LEFT_KEY) ) sprite_set_dx(s1, -1);
+        else if ( key_down( RIGHT_KEY) ) sprite_set_dx(s1, 1);
+        else sprite_set_dx(s1, 0);
 
-        if ( key_down( UP_KEY) ) sprite_set_dy(s, -1);
-        else if ( key_down( DOWN_KEY) ) sprite_set_dy(s, 1);
-        else sprite_set_dy(s, 0);
+        if ( key_down( UP_KEY) ) sprite_set_dy(s1, -1);
+        else if ( key_down( DOWN_KEY) ) sprite_set_dy(s1, 1);
+        else sprite_set_dy(s1, 0);
+
+
+        if ( key_down( A_KEY) ) sprite_set_dx(s2, -1);
+        else if ( key_down( D_KEY) ) sprite_set_dx(s2, 1);
+        else sprite_set_dx(s2, 0);
+
+        if ( key_down( W_KEY) ) sprite_set_dy(s2, -1);
+        else if ( key_down( S_KEY) ) sprite_set_dy(s2, 1);
+        else sprite_set_dy(s2, 0);
+
+
+        if ( key_down( J_KEY) ) sprite_set_dx(s3, -1);
+        else if ( key_down( L_KEY) ) sprite_set_dx(s3, 1);
+        else sprite_set_dx(s3, 0);
+
+        if ( key_down( I_KEY) ) sprite_set_dy(s3, -1);
+        else if ( key_down( K_KEY) ) sprite_set_dy(s3, 1);
+        else sprite_set_dy(s3, 0);
 
         if ( key_typed(F_KEY) )
         {
             follow = not follow;
         }
 
-        update_sprite(s);
+        update_sprite(s1);
+        update_sprite(s2);
+        update_sprite(s3);
 
-        if ( follow )
-        {
-            center_camera_on(s, 0, 0);
-        }
-        else
-        {
+        if ( follow ){
+            center_camera_on(arr, 0, 0);
+        }else{
             set_camera_x(0);
             set_camera_y(0);
         }
@@ -65,7 +94,9 @@ void run_camera_test()
 
         draw_triangle(COLOR_AQUA, screen_width() / 2, 0, 0, screen_height(), screen_width(), screen_height());
 
-        draw_sprite(s);
+        draw_sprite(s1);
+        draw_sprite(s2);
+        draw_sprite(s3);
         refresh_screen();
     }
 


### PR DESCRIPTION
# Description
Added in support for vector array and static array for center_camera_on() method for C++ as calculating multiple sprite locations can be tedious.
```cpp
void center_camera_on(vector<sprite> s, double offset_x, double offset_y);
```
parameters:

- `vector<sprite> s`
- `double offset_x`
- `double offset_y`

```cpp
void center_camera_on(sprite s[],int size , double offset_x, double offset_y);
```
parameters:

- `sprite s[]`
- `int size`
- `double offset_x`
- `double offset_y`
Both supports vector_2d data sets too:
```cpp
	//static arr
	void center_camera_on(sprite s[],int size , const vector_2d &offset);
	//vector arr
	void center_camera_on(vector<sprite> s, const vector_2d &offset)
```

**Video demo:**

https://github.com/splashkit/splashkit-core/assets/128771372/ab3c07b4-edf8-41b1-b600-25aa9ed87094


## Type of change

- [x] Overloading the method in camera.cpp and camera.h file
- [x] Modified the camera test to check the functionality 

# How Has This Been Tested?

- [x] Tested with Windows 10
- [x] Test on single variable, vector array and static array
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Requested a review from seniors on the Pull Request

