### PR TITLE
Add ability to compile to WebAssembly under Emscripten

### DIFF
--- a/coresdk/lib/wasm/curl.cpp
+++ b/coresdk/lib/wasm/curl.cpp
@@ -1,0 +1,19 @@
+#include "curl/curl.h"
+
+CURL_EXTERN CURLcode curl_global_init(long flags){return CURLE_OK;}
+CURL_EXTERN void curl_global_cleanup(void){}
+
+CURL_EXTERN CURL *curl_easy_init(void){return nullptr;}
+CURL_EXTERN CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...){return CURLE_OK;}
+CURL_EXTERN CURLcode curl_easy_perform(CURL *curl){return CURLE_OK;}
+CURL_EXTERN void curl_easy_cleanup(CURL *curl){}
+CURL_EXTERN const char *curl_easy_strerror(CURLcode){return "cURL (and anything using the web driver) is not supported under WASM";}
+CURL_EXTERN CURLcode curl_easy_getinfo(CURL *curl, CURLINFO info, ...){
+	//if (info==CURLINFO_CONTENT_TYPE)
+		//TODO: set first argument to nullptr
+	return CURLE_OK;
+}
+CURL_EXTERN struct curl_slist *curl_slist_append(struct curl_slist *,
+                                                 const char *){return nullptr;}
+
+CURL_EXTERN void curl_slist_free_all(struct curl_slist *){}

--- a/coresdk/lib/wasm/ncurses.cpp
+++ b/coresdk/lib/wasm/ncurses.cpp
@@ -1,0 +1,170 @@
+#include <ncursesw/ncurses.h>
+
+int COLORS = 0;
+WINDOW * stdscr = nullptr;
+
+extern NCURSES_EXPORT(int) use_default_colors (void){return 0;}
+
+extern NCURSES_EXPORT(int) clear (void){return 0;}				/* generated */
+extern NCURSES_EXPORT(int) move (int, int){return 0;}				/* generated */
+extern NCURSES_EXPORT(int) refresh (void){return 0;}				/* generated */
+
+extern NCURSES_EXPORT(int) baudrate (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) beep  (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(bool) can_change_color (void){return false;}			/* implemented */
+extern NCURSES_EXPORT(int) cbreak (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) clearok (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) color_content (NCURSES_COLOR_T,NCURSES_COLOR_T*,NCURSES_COLOR_T*,NCURSES_COLOR_T*){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) copywin (const WINDOW*,WINDOW*,int,int,int,int,int,int,int){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) curs_set (int){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) def_prog_mode (void){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) def_shell_mode (void){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) delay_output (int){return 0;}				/* implemented */
+extern NCURSES_EXPORT(void) delscreen (SCREEN *){}			/* implemented */
+extern NCURSES_EXPORT(int) delwin (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(WINDOW *) derwin (WINDOW *,int,int,int,int){return nullptr;}	/* implemented */
+extern NCURSES_EXPORT(int) doupdate (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(WINDOW *) dupwin (WINDOW *){return nullptr;}			/* implemented */
+extern NCURSES_EXPORT(int) echo (void){return 0;}					/* implemented */
+extern NCURSES_EXPORT(int) endwin (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(char) erasechar (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(void) filter (void){}				/* implemented */
+extern NCURSES_EXPORT(int) flash (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) flushinp (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(WINDOW *) getwin (FILE *){return nullptr;}			/* implemented */
+extern NCURSES_EXPORT(int) halfdelay (int){return 0;}				/* implemented */
+extern NCURSES_EXPORT(bool) has_colors (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(bool) has_ic (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(bool) has_il (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(void) idcok (WINDOW *, bool){}			/* implemented */
+extern NCURSES_EXPORT(int) idlok (WINDOW *, bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(void) immedok (WINDOW *, bool){}			/* implemented */
+extern NCURSES_EXPORT(WINDOW *) initscr (void){return nullptr;}				/* implemented */
+extern NCURSES_EXPORT(int) init_color (NCURSES_COLOR_T,NCURSES_COLOR_T,NCURSES_COLOR_T,NCURSES_COLOR_T){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) init_pair (NCURSES_PAIRS_T,NCURSES_COLOR_T,NCURSES_COLOR_T){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) intrflush (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(bool) isendwin (void){return false;}				/* implemented */
+extern NCURSES_EXPORT(bool) is_linetouched (WINDOW *,int){return false;}		/* implemented */
+extern NCURSES_EXPORT(bool) is_wintouched (WINDOW *){return false;}			/* implemented */
+extern NCURSES_EXPORT(NCURSES_CONST char *) keyname (int){return nullptr;}		/* implemented */
+extern NCURSES_EXPORT(int) keypad (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(char) killchar (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) leaveok (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(char *) longname (void){return nullptr;}				/* implemented */
+extern NCURSES_EXPORT(int) meta (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) mvcur (int,int,int,int){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) mvderwin (WINDOW *, int, int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) mvprintw (int,int, const char *,...)		/* implemented */
+		GCC_PRINTFLIKE(3,4){return 0;}
+extern NCURSES_EXPORT(int) mvscanw (int,int, NCURSES_CONST char *,...)	/* implemented */
+		GCC_SCANFLIKE(3,4){return 0;}
+extern NCURSES_EXPORT(int) mvwin (WINDOW *,int,int){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) mvwprintw (WINDOW*,int,int, const char *,...)	/* implemented */
+		GCC_PRINTFLIKE(4,5){return 0;}
+extern NCURSES_EXPORT(int) mvwscanw (WINDOW *,int,int, NCURSES_CONST char *,...)	/* implemented */
+		GCC_SCANFLIKE(4,5){return 0;}
+extern NCURSES_EXPORT(int) napms (int){return 0;}					/* implemented */
+extern NCURSES_EXPORT(WINDOW *) newpad (int,int){return nullptr;}		       	/* implemented */
+extern NCURSES_EXPORT(SCREEN *) newterm (NCURSES_CONST char *,FILE *,FILE *){return nullptr;}	/* implemented */
+extern NCURSES_EXPORT(WINDOW *) newwin (int,int,int,int){return nullptr;}	       	/* implemented */
+extern NCURSES_EXPORT(int) nl (void){return 0;}					/* implemented */
+extern NCURSES_EXPORT(int) nocbreak (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) nodelay (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) noecho (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) nonl (void){return 0;}					/* implemented */
+extern NCURSES_EXPORT(void) noqiflush (void){}				/* implemented */
+extern NCURSES_EXPORT(int) noraw (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) notimeout (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) overlay (const WINDOW*,WINDOW *){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) overwrite (const WINDOW*,WINDOW *){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) pair_content (NCURSES_PAIRS_T,NCURSES_COLOR_T*,NCURSES_COLOR_T*){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) pechochar (WINDOW *, const chtype){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) pnoutrefresh (WINDOW*,int,int,int,int,int,int){return 0;}/* implemented */
+extern NCURSES_EXPORT(int) prefresh (WINDOW *,int,int,int,int,int,int){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) printw (const char *,...)			/* implemented */
+		GCC_PRINTFLIKE(1,2){return 0;}
+extern NCURSES_EXPORT(int) putwin (WINDOW *, FILE *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(void) qiflush (void){}				/* implemented */
+extern NCURSES_EXPORT(int) raw (void){return 0;}					/* implemented */
+extern NCURSES_EXPORT(int) resetty (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) reset_prog_mode (void){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) reset_shell_mode (void){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) ripoffline (int, int (*)(WINDOW *, int)){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) savetty (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) scanw (NCURSES_CONST char *,...)		/* implemented */
+		GCC_SCANFLIKE(1,2){return 0;}
+extern NCURSES_EXPORT(int) scr_dump (const char *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) scr_init (const char *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) scrollok (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) scr_restore (const char *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) scr_set (const char *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(SCREEN *) set_term (SCREEN *){return nullptr;}			/* implemented */
+extern NCURSES_EXPORT(int) slk_attroff (const chtype){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) slk_attron (const chtype){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) slk_attrset (const chtype){return 0;}			/* implemented */
+extern NCURSES_EXPORT(attr_t) slk_attr (void){return (attr_t){};}				/* implemented */
+extern NCURSES_EXPORT(int) slk_attr_set (const attr_t,NCURSES_PAIRS_T,void*){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) slk_clear (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) slk_color (NCURSES_PAIRS_T){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) slk_init (int){return 0;}				/* implemented */
+extern NCURSES_EXPORT(char *) slk_label (int){return nullptr;}				/* implemented */
+extern NCURSES_EXPORT(int) slk_noutrefresh (void){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) slk_refresh (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) slk_restore (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) slk_set (int,const char *,int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) slk_touch (void){return 0;}	      	       		/* implemented */
+extern NCURSES_EXPORT(int) start_color (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(WINDOW *) subpad (WINDOW *, int, int, int, int){return nullptr;}	/* implemented */
+extern NCURSES_EXPORT(WINDOW *) subwin (WINDOW *, int, int, int, int){return nullptr;}	/* implemented */
+extern NCURSES_EXPORT(int) syncok (WINDOW *, bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(chtype) termattrs (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(char *) termname (void){return nullptr;}				/* implemented */
+extern NCURSES_EXPORT(int) typeahead (int){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) ungetch (int){return 0;}				/* implemented */
+extern NCURSES_EXPORT(void) use_env (bool){}				/* implemented */
+extern NCURSES_EXPORT(void) use_tioctl (bool){}				/* implemented */
+extern NCURSES_EXPORT(int) vidattr (chtype){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) vidputs (chtype, NCURSES_OUTC){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) vwprintw (WINDOW *, const char *,va_list){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) vwscanw (WINDOW *, NCURSES_CONST char *,va_list){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) waddch (WINDOW *, const chtype){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) waddchnstr (WINDOW *,const chtype *,int){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) waddnstr (WINDOW *,const char *,int){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) wattr_on (WINDOW *, attr_t, void *){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) wattr_off (WINDOW *, attr_t, void *){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) wbkgd (WINDOW *, chtype){return 0;}			/* implemented */
+extern NCURSES_EXPORT(void) wbkgdset (WINDOW *,chtype){}			/* implemented */
+extern NCURSES_EXPORT(int) wborder (WINDOW *,chtype,chtype,chtype,chtype,chtype,chtype,chtype,chtype){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) wchgat (WINDOW *, int, attr_t, NCURSES_PAIRS_T, const void *){return 0;}/* implemented */
+extern NCURSES_EXPORT(int) wclear (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) wclrtobot (WINDOW *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) wclrtoeol (WINDOW *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) wcolor_set (WINDOW*,NCURSES_PAIRS_T,void*){return 0;}		/* implemented */
+extern NCURSES_EXPORT(void) wcursyncup (WINDOW *){}			/* implemented */
+extern NCURSES_EXPORT(int) wdelch (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) wechochar (WINDOW *, const chtype){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) werase (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) wgetch (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) wgetnstr (WINDOW *,char *,int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) whline (WINDOW *, chtype, int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(chtype) winch (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) winchnstr (WINDOW *, chtype *, int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) winnstr (WINDOW *, char *, int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) winsch (WINDOW *, chtype){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) winsdelln (WINDOW *,int){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) winsnstr (WINDOW *, const char *,int){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) wmove (WINDOW *,int,int){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) wnoutrefresh (WINDOW *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) wprintw (WINDOW *, const char *,...)		/* implemented */
+		GCC_PRINTFLIKE(2,3){return 0;}
+extern NCURSES_EXPORT(int) wredrawln (WINDOW *,int,int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) wrefresh (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) wscanw (WINDOW *, NCURSES_CONST char *,...)	/* implemented */
+		GCC_SCANFLIKE(2,3){return 0;}
+extern NCURSES_EXPORT(int) wscrl (WINDOW *,int){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) wsetscrreg (WINDOW *,int,int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(void) wsyncdown (WINDOW *){}			/* implemented */
+extern NCURSES_EXPORT(void) wsyncup (WINDOW *){}				/* implemented */
+extern NCURSES_EXPORT(void) wtimeout (WINDOW *,int){}			/* implemented */
+extern NCURSES_EXPORT(int) wtouchln (WINDOW *,int,int,int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) wvline (WINDOW *,chtype,int){return 0;}		/* implemented */

--- a/coresdk/src/backend/core_driver.cpp
+++ b/coresdk/src/backend/core_driver.cpp
@@ -40,7 +40,11 @@ namespace splashkit_lib
         el::Loggers::reconfigureAllLoggers(el::ConfigurationType::Format, "%datetime %level: %msg");
 
         // LOG(TRACE) << "About to initialise splashkit";
+#ifdef __EMSCRIPTEN__
+        if ( -1 == SDL_Init( SDL_INIT_EVERYTHING & ~(SDL_INIT_TIMER | SDL_INIT_HAPTIC) ) )
+#else
         if ( -1 == SDL_Init( SDL_INIT_EVERYTHING ) )
+#endif
         {
             // fatal error so...
             // no other functions can now be called

--- a/coresdk/src/backend/utility_functions.cpp
+++ b/coresdk/src/backend/utility_functions.cpp
@@ -154,7 +154,8 @@ namespace splashkit_lib
         
         // LOG(TRACE) << "Adding dir: " << directory;
 
-        for (const auto& dir_entry : recursive_directory_iterator(directory))
+        std::error_code ec;
+        for (const auto& dir_entry : recursive_directory_iterator(directory, {}, ec))
         {
             if(dir_entry.is_directory())
             {

--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -17,6 +17,10 @@ if (WIN32 OR MSYS OR MINGW)
   add_definitions(-DWINDOWS)
 endif()
 
+if(EMSCRIPTEN)
+  SET(MSYS "false")
+endif()
+
 #### SETUP ####
 if (APPLE)
     # MAC OS PROJECT FLAGS
@@ -73,6 +77,36 @@ elseif(MSYS)
                     -L/${MINGW_PATH_PART}/lib \
                     -L/usr/lib \
                     -lSDL2main")
+# EMSCRIPTEN PROJECT FLAGS
+elseif(EMSCRIPTEN)
+    message("Using emscripten")
+    set(LIB_FLAGS "-lpthread \
+                   -ldl \
+                   -s LINKABLE=1 \
+                   -s EXPORT_ALL=1 \
+                   -sUSE_SDL=2 \
+                   -sUSE_SDL_TTF=2 \
+                   -sUSE_SDL_GFX=2 \
+                   -sUSE_SDL_NET=2 \
+                   -sUSE_SDL_MIXER=2 \
+                   -sUSE_SDL_IMAGE=2 \
+                   -sSDL2_IMAGE_FORMATS='[\"bmp\",\"png\",\"xpm\"]'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -sUSE_SDL=2")
+
+    file(GLOB BUILD_AS_WINDOWS_FILES
+        "${SK_EXT}/civetweb/src/civetweb.c"
+        "${SK_EXT}/sqlite/sqlite3.c"
+        "${SK_EXT}/hash-library/*.cpp"
+        "${SK_SRC}/coresdk/terminal.cpp"
+    )
+    file(GLOB BUILD_AS_LINUX_FILES
+        "${SK_EXT}/easyloggingpp/*.cc"
+    )
+
+    set_source_files_properties(${BUILD_AS_WINDOWS_FILES} PROPERTIES COMPILE_DEFINITIONS "WINDOWS")
+    set_source_files_properties(${BUILD_AS_LINUX_FILES} PROPERTIES COMPILE_DEFINITIONS "__linux")
+    set(CMAKE_EXECUTABLE_SUFFIX ".html")
+
 # LINUX PROJECT FLAGS
 else()
     set(LIB_FLAGS "-lSDL2 \
@@ -110,6 +144,13 @@ file(GLOB SOURCE_FILES
     "${SK_EXT}/easyloggingpp/*.cc"
 )
 
+if (EMSCRIPTEN)
+  file(GLOB WASM_SOURCE_FILES
+    "${SK_LIB}/wasm/*.cpp"
+  )
+  set(SOURCE_FILES ${SOURCE_FILES} ${WASM_SOURCE_FILES})
+endif()
+
 # TEST FILE INCLUDES
 file(GLOB TEST_SOURCE_FILES
     "${SK_SRC}/test/*.cpp"
@@ -137,7 +178,7 @@ include_directories("${SK_EXT}/sqlite")
 include_directories("${SK_EXT}/catch")
 
 # MAC OS AND WINDOWS DIRECTORY INCLUDES
-if (APPLE OR MSYS)
+if (APPLE OR MSYS OR EMSCRIPTEN)
     include_directories("${SK_EXT}/SDL/include")
     include_directories("${SK_EXT}/SDL_gfx")
     include_directories("${SK_EXT}/SDL_image")
@@ -150,7 +191,7 @@ if (APPLE)
     include_directories("${SK_EXT}/SDL_image/external/libpng-1.6.2")
 endif()
 # WINDOWS ONLY DIRECTORY INCLUDES
-if (MSYS)
+if (MSYS OR EMSCRIPTEN)
     include_directories(/${MINGW_PATH_PART}/include)
     include_directories(/${MINGW_PATH_PART}/include/libpng16)
     include_directories("${SK_LIB}/win_inc")
@@ -223,6 +264,11 @@ add_custom_command(TARGET sktest
     PRE_BUILD COMMAND
     ${CMAKE_COMMAND} -E copy_directory "${SK_SRC}/test/Resources" $<TARGET_FILE_DIR:sktest>/Resources)
 
+
+if (EMSCRIPTEN)
+    set_target_properties(sktest PROPERTIES LINK_FLAGS "--preload-file ${SK_SRC}/test/Resources@Resources")
+endif()
+
 # if (MSYS)
 #     add_custom_command(TARGET sktest
 #         PRE_BUILD COMMAND
@@ -239,6 +285,10 @@ set_property(TARGET skunit_tests PROPERTY POSITION_INDEPENDENT_CODE FALSE)
 # target_link_options(skunit_tests PUBLIC "LINKER:-U,___darwin_check_fd_set_overflow")
 target_link_libraries(skunit_tests SplashKitBackend)
 target_link_libraries(skunit_tests ${LIB_FLAGS})
+
+if (EMSCRIPTEN)
+    set_target_properties(skunit_tests PROPERTIES LINK_FLAGS "--preload-file ${SK_SRC}/test/Resources@Resources")
+endif()
 
 set_target_properties(skunit_tests
         PROPERTIES


### PR DESCRIPTION
_Edit: Resubmitted to ThothTech/splashkit-core - sorry for submitting it here!_
This pull request makes SplashKit compilable to WebAssembly using Emscripten.
There are three main changes:
- **CMakeLists** has been modified to detect an Emscripten build, and modify flags and includes appropriately.
Most of the build behaves similar to (and imitates) the Linux one, however like in the Windows build, extra include files are passed in.
Additionally, some of the external dependencies only compile succesfully if not linux (they do extra work to make it work on Windows, which is also required under Emscripten), so for those libraries WINDOWS is passed in as a macro.
- **Stubs for curl and ncurses** have been added. These stubs are purely intended to allow compilation, and are not intended to be functional - they shouldn't cause issues if called however.
- **Initialization changes** have been made in core_driver.cpp and utility_functions.cpp, to ensure correct startup.

The following steps are required to build:
1. Install and activate Emscripten via the `emsdk`. Installation instructions are here - [Getting Started](https://emscripten.org/docs/getting_started/downloads.html)
2. Compile with the following (currently only tested under cmd, as mingw64 shell gives path issues)
```bash
cd splashkit-core\projects\cmake
SET EMSCRIPTEN=%EMSDK%/upstream/emscripten #or if on linux, the bash equivalent
emcmake cmake -G "Unix Makefiles" .
emmake make
```

The resulting output cannot be directly used as a library, however it can be loaded in the browser. The tests partially run in the browser; they would require source code changes to fully function. They currently freeze the browser until stopped (due to executing synchronously with the browser's interface), where the last frame is left visible. This however confirms they are functioning.