### PR TITLE
Fix initialization under Emscripten

### DIFF
--- a/coresdk/src/backend/core_driver.cpp
+++ b/coresdk/src/backend/core_driver.cpp
@@ -40,7 +40,11 @@ namespace splashkit_lib
         el::Loggers::reconfigureAllLoggers(el::ConfigurationType::Format, "%datetime %level: %msg");
 
         // LOG(TRACE) << "About to initialise splashkit";
+#ifdef __EMSCRIPTEN__
+        if ( -1 == SDL_Init( SDL_INIT_EVERYTHING & ~(SDL_INIT_TIMER | SDL_INIT_HAPTIC) ) )
+#else
         if ( -1 == SDL_Init( SDL_INIT_EVERYTHING ) )
+#endif
         {
             // fatal error so...
             // no other functions can now be called

--- a/coresdk/src/backend/utility_functions.cpp
+++ b/coresdk/src/backend/utility_functions.cpp
@@ -154,7 +154,9 @@ namespace splashkit_lib
         
         // LOG(TRACE) << "Adding dir: " << directory;
 
-        for (const auto& dir_entry : recursive_directory_iterator(directory))
+        std::error_code ec;
+
+        for (const auto& dir_entry : recursive_directory_iterator(directory, {}, ec))
         {
             if(dir_entry.is_directory())
             {


### PR DESCRIPTION
This pull request fixes some issues encountered during initialization in an Emscripten-based WebAssembly build (used in SplashKit Online).

 - SDL fails to initialize:
   - Make SDL only initialize parts that function in the browser.
 - The font initialization tries to access a path that doesn't exist in the browser's ram FS:
   - Patch `scan_dir_recursive` to not throw an exception if the path doesn't exist.

I'm fairly sure this shouldn't break any existing code. 
 - The SDL init change is wrapped in an `ifdef` and so will only affect Emscripten builds.
 - `scan_dir_recursive` is only used in the function `load_system_font_paths()` inside text_driver.cpp, and I was unable to find any code that catches exceptions along the chain of functions that call it, so unless a user of SplashKit relies on catching this exception, it shouldn't cause any issues.

Another option was to check if the directory exists before creating the `recursive_directory_iterator`, however there could theoretically be a race condition (in the unlikely event the directory is deleted between calls), so I opted for the current patch instead just in case.