### PR TITLE
Fix triangle-rectangle intersection bug

### DIFF
--- a/coresdk/src/coresdk/triangle_geometry.cpp
+++ b/coresdk/src/coresdk/triangle_geometry.cpp
@@ -58,7 +58,7 @@ namespace splashkit_lib
             // otherwise it's on the right
             else
             {
-                top_intersection    = m * l + c;
+                top_intersection    = m * r + c;
                 bottom_intersection = m * l + c;
             }
 


### PR DESCRIPTION
There's an error in the `triangle_rectangle_intersect` function where intersections aren't being detected due to it using the incorrect edge of the rectangle for the intersection calculation. This occurs when the rectangle is colliding with the right side of an upside down triangle (pictured).

![Untitled](https://github.com/splashkit/splashkit-core/assets/25257393/60f953cc-e6e6-4aca-a1cd-85ff3c8a5f32)
