### PR TITLE
Fix text_driver returning wrong size for non Latin-1 characters

### DIFF
--- a/coresdk/src/backend/text_driver.cpp
+++ b/coresdk/src/backend/text_driver.cpp
@@ -183,7 +183,7 @@ namespace splashkit_lib
 
         if (ttf_font)
         {
-            return TTF_SizeText(ttf_font, text.c_str(), w, h);
+            return TTF_SizeUTF8(ttf_font, text.c_str(), w, h);
         }
         else
         {


### PR DESCRIPTION
PR duplicated from thoth-tech/splashkit-core#40
Commits were rebased.
# Description

`sk_text_size` uses `TTF_SizeText` internally to calculate the size of the text. This function is only expecting Latin-1 encoded text, and as such doesn't work properly when given most Unicode characters. This PR just replaces `TTF_SizeText` with `TTF_SizeUTF8`, which makes it take Unicode now instead, matching the rest of the `text_driver.cpp` functions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The size returned from `sk_text_size` with various non English strings has been checked and shown to properly fit the returned text. Without the commit, the width returned is too long.

Can be tested with the following:
```c++
font fontA = load_font("font 1", "kochi-gothic-subst.ttf");

string testA = "Hello!";
draw_text(testA, COLOR_BLACK, fontA, 15, 0, 10);
draw_rectangle(COLOR_BLACK, 0, 10, text_width(testA, fontA, 15), text_height(testA, fontA, 15));

string testB = "どこへ行っても…ね？";
draw_text(testB, COLOR_BLACK, fontA, 15, 0, 25);
draw_rectangle(COLOR_BLACK, 0, 25, text_width(testB, fontA, 15), text_height(testB, fontA, 15));

refresh_screen();
delay(4000);
```
With the commit, the rectangles surround the text accurately - without, the rectangle around the Japanese text is too long.
## Testing Checklist

- [x] Tested with sktest
- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
