### PR TITLE
Fix GPIO Tests

### DIFF
--- a/tools/scripts/install-win-libraries.sh
+++ b/tools/scripts/install-win-libraries.sh
@@ -2,3 +2,6 @@
 
 echo "This is just a start... need to complete the list!"
 pacman -S git mingw-w64-x86_64-toolchain mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-cmake make mingw-w64-x86_64-SDL2_mixer mingw-w64-x86_64-civetweb
+
+echo "To check libraries used..."
+ldd SplashKit.dll | grep mingw64 | sed 's/.*=> /cp /' - | sed 's/ (.*)/ ./' -


### PR DESCRIPTION
## Description

PR duplicated from https://github.com/thoth-tech/splashkit-core/pull/35

When the project is compiled from the projects folder, as per CONTRIBUTING.md and then the GPIO tests from `./sktest` are run it results in errors.

These errors are due to a typo in `raspi_gpio.cpp` and an error in the logic of `check_pi()` in `gpio_driver.cpp`.

`check_pi` return true only when `pigpio_start` has returned a negative value, which indicates an error. Thus, its use later on to in `sk_gpio_read` means that pin readings are only attempted on non-compatible boards.

Fixes [#167](https://github.com/splashkit/splashkit-core/issues/167)

## Type of change

- [x]  Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`sktest` was rerun after the changes, and the tests behave as expected.

## Checklist

- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  My changes generate no new warnings
- [x]  I have requested a review from Aditya Parmar on the Pull Request