### PR TITLE
 Fix any_key_pressed()

### DIFF
--- a/coresdk/src/coresdk/keyboard_input.cpp
+++ b/coresdk/src/coresdk/keyboard_input.cpp
@@ -6,21 +6,16 @@
 //  Copyright © 2016 Andrew Cain. All rights reserved.
 //
 
-
 #include "keyboard_input.h"
-
 
 #include "input_driver.h"
 #include "utility_functions.h"
 
-
 #include <vector>
 #include <map>
 
-
 using std::vector;
 using std::map;
-
 
 namespace splashkit_lib
 {
@@ -29,47 +24,39 @@ namespace splashkit_lib
     static map<key_code, bool> _keys_released; // i.e. those that have just gone up
     static bool _key_pressed = false;
 
-
     static vector<key_callback *> _on_key_down;
     static vector<key_callback *> _on_key_up;
     static vector<key_callback *> _on_key_typed;
-
 
     void register_callback_on_key_down(key_callback *callback)
     {
         _on_key_down.push_back(callback);
     }
 
-
     void register_callback_on_key_up(key_callback *callback)
     {
         _on_key_up.push_back(callback);
     }
-
 
     void register_callback_on_key_typed(key_callback *callback)
     {
         _on_key_typed.push_back(callback);
     }
 
-
     void deregister_callback_on_key_down(key_callback *callback)
     {
         _on_key_down.erase(std::remove(_on_key_down.begin(), _on_key_down.end(), callback), _on_key_down.end());
     }
-
 
     void deregister_callback_on_key_up(key_callback *callback)
     {
         _on_key_up.erase(std::remove(_on_key_up.begin(), _on_key_up.end(), callback), _on_key_up.end());
     }
 
-
     void deregister_callback_on_key_typed(key_callback *callback)
     {
         _on_key_typed.erase(std::remove(_on_key_typed.begin(), _on_key_typed.end(), callback), _on_key_typed.end());
     }
-
 
     void _raise_key_event(vector<key_callback *> &list, key_code code)
     {
@@ -81,13 +68,11 @@ namespace splashkit_lib
         }
     }
 
-
     void _keyboard_start_process_events()
     {
         _keys_just_typed.clear();
         _keys_released.clear();
     }
-
 
     void _handle_key_up_callback(key_code code)
     {
@@ -97,7 +82,6 @@ namespace splashkit_lib
         _key_pressed = false;
         _raise_key_event(_on_key_up, keycode);
     }
-
 
     void _handle_key_down_callback(key_code code)
     {
@@ -112,12 +96,10 @@ namespace splashkit_lib
         _raise_key_event(_on_key_down, keycode);
     }
 
-
     bool key_down(key_code key)
     {
         return _keys_down.count(key) > 0 and _keys_down[key];
     }
-
 
     bool key_typed(key_code key)
     {

--- a/coresdk/src/coresdk/keyboard_input.cpp
+++ b/coresdk/src/coresdk/keyboard_input.cpp
@@ -22,7 +22,6 @@ namespace splashkit_lib
     static map<key_code, bool> _keys_down;
     static map<key_code, bool> _keys_just_typed; // i.e. those that have just gone down
     static map<key_code, bool> _keys_released; // i.e. those that have just gone up
-    static bool _key_pressed = false;
 
     static vector<key_callback *> _on_key_down;
     static vector<key_callback *> _on_key_up;
@@ -78,8 +77,7 @@ namespace splashkit_lib
     {
         key_code keycode = static_cast<key_code>(code);
         _keys_released[keycode] = true;
-        _keys_down[keycode] = false;
-        _key_pressed = false;
+        _keys_down.erase(keycode);
         _raise_key_event(_on_key_up, keycode);
     }
 
@@ -92,7 +90,6 @@ namespace splashkit_lib
             _keys_just_typed[keycode] = true;
             _raise_key_event(_on_key_typed, keycode);
         }
-        _key_pressed = true;
         _raise_key_event(_on_key_down, keycode);
     }
 
@@ -113,7 +110,14 @@ namespace splashkit_lib
     
     bool any_key_pressed()
     {
-        return _key_pressed;
+        if (_keys_down.size() > 0)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
     }
     
     string key_name(key_code key)

--- a/coresdk/src/coresdk/keyboard_input.cpp
+++ b/coresdk/src/coresdk/keyboard_input.cpp
@@ -6,16 +6,21 @@
 //  Copyright © 2016 Andrew Cain. All rights reserved.
 //
 
+
 #include "keyboard_input.h"
+
 
 #include "input_driver.h"
 #include "utility_functions.h"
 
+
 #include <vector>
 #include <map>
 
+
 using std::vector;
 using std::map;
+
 
 namespace splashkit_lib
 {
@@ -24,39 +29,47 @@ namespace splashkit_lib
     static map<key_code, bool> _keys_released; // i.e. those that have just gone up
     static bool _key_pressed = false;
 
+
     static vector<key_callback *> _on_key_down;
     static vector<key_callback *> _on_key_up;
     static vector<key_callback *> _on_key_typed;
+
 
     void register_callback_on_key_down(key_callback *callback)
     {
         _on_key_down.push_back(callback);
     }
 
+
     void register_callback_on_key_up(key_callback *callback)
     {
         _on_key_up.push_back(callback);
     }
+
 
     void register_callback_on_key_typed(key_callback *callback)
     {
         _on_key_typed.push_back(callback);
     }
 
+
     void deregister_callback_on_key_down(key_callback *callback)
     {
         _on_key_down.erase(std::remove(_on_key_down.begin(), _on_key_down.end(), callback), _on_key_down.end());
     }
+
 
     void deregister_callback_on_key_up(key_callback *callback)
     {
         _on_key_up.erase(std::remove(_on_key_up.begin(), _on_key_up.end(), callback), _on_key_up.end());
     }
 
+
     void deregister_callback_on_key_typed(key_callback *callback)
     {
         _on_key_typed.erase(std::remove(_on_key_typed.begin(), _on_key_typed.end(), callback), _on_key_typed.end());
     }
+
 
     void _raise_key_event(vector<key_callback *> &list, key_code code)
     {
@@ -68,20 +81,23 @@ namespace splashkit_lib
         }
     }
 
+
     void _keyboard_start_process_events()
     {
-        _key_pressed = false;
         _keys_just_typed.clear();
         _keys_released.clear();
     }
+
 
     void _handle_key_up_callback(key_code code)
     {
         key_code keycode = static_cast<key_code>(code);
         _keys_released[keycode] = true;
         _keys_down[keycode] = false;
+        _key_pressed = false;
         _raise_key_event(_on_key_up, keycode);
     }
+
 
     void _handle_key_down_callback(key_code code)
     {
@@ -92,13 +108,16 @@ namespace splashkit_lib
             _keys_just_typed[keycode] = true;
             _raise_key_event(_on_key_typed, keycode);
         }
+        _key_pressed = true;
         _raise_key_event(_on_key_down, keycode);
     }
+
 
     bool key_down(key_code key)
     {
         return _keys_down.count(key) > 0 and _keys_down[key];
     }
+
 
     bool key_typed(key_code key)
     {

--- a/coresdk/src/test/test_input.cpp
+++ b/coresdk/src/test/test_input.cpp
@@ -1,4 +1,3 @@
-```
 //
 //  test_input.cpp
 //  splashkit

--- a/coresdk/src/test/test_input.cpp
+++ b/coresdk/src/test/test_input.cpp
@@ -6,15 +6,12 @@
 //  Copyright © 2016 Andrew Cain. All rights reserved.
 //
 
-
 #include "graphics.h"
 #include "input.h"
 #include "text.h"
 
-
 using namespace splashkit_lib;
 using namespace std;
-
 
 static string _key_typed = "", _key_down = "", _key_up = "";
 
@@ -24,18 +21,15 @@ void _on_key_typed(int code)
     _key_typed = key_name( static_cast<key_code>(code));
 }
 
-
 void _on_key_down(int code)
 {
     _key_down = key_name( static_cast<key_code>(code) );
 }
 
-
 void _on_key_up(int code)
 {
     _key_up = key_name( static_cast<key_code>(code) );
 }
-
 
 void run_input_test()
 {
@@ -92,18 +86,13 @@ void run_input_test()
         if(any_key_pressed()) any_key_input += "yes";
         else any_key_input += "no";
 
-
         string key_details = "T key is ";
         if ( key_down(T_KEY) ) key_details += "down";
         if ( key_up(T_KEY) ) key_details += "up";
         if ( key_released(T_KEY) ) key_details += " - released";
         if ( key_typed(T_KEY) ) key_details += " - typed";
-        
-
-
         if ( key_typed(F_KEY) ) window_toggle_fullscreen(window_with_focus());
         if ( key_typed(B_KEY) ) window_toggle_border(window_with_focus());
-
 
         draw_text(location, COLOR_PLUM, "hara", 14, 18, 200);
         draw_text(left_clicked, COLOR_PLUM, "hara", 14, 18, 220);
@@ -113,7 +102,6 @@ void run_input_test()
         draw_text(_key_down, COLOR_PLUM, "hara", 14, 18, 300);
         draw_text(_key_up, COLOR_PLUM, "hara", 14, 18, 320);
         draw_text(_key_typed, COLOR_PLUM, "hara", 14, 18, 340);
-        
         
         set_current_window(w2);
         

--- a/coresdk/src/test/test_input.cpp
+++ b/coresdk/src/test/test_input.cpp
@@ -158,6 +158,3 @@ void run_input_test()
     
     free_all_fonts();
 }
-
-
-```

--- a/coresdk/src/test/test_input.cpp
+++ b/coresdk/src/test/test_input.cpp
@@ -1,3 +1,4 @@
+```
 //
 //  test_input.cpp
 //  splashkit
@@ -6,29 +7,36 @@
 //  Copyright © 2016 Andrew Cain. All rights reserved.
 //
 
+
 #include "graphics.h"
 #include "input.h"
 #include "text.h"
 
+
 using namespace splashkit_lib;
 using namespace std;
 
+
 static string _key_typed = "", _key_down = "", _key_up = "";
+
 
 void _on_key_typed(int code)
 {
     _key_typed = key_name( static_cast<key_code>(code));
 }
 
+
 void _on_key_down(int code)
 {
     _key_down = key_name( static_cast<key_code>(code) );
 }
 
+
 void _on_key_up(int code)
 {
     _key_up = key_name( static_cast<key_code>(code) );
 }
+
 
 void run_input_test()
 {
@@ -81,22 +89,32 @@ void run_input_test()
         string right_clicked = "Right click status: ";
         right_clicked += to_string(mouse_clicked(RIGHT_BUTTON)) + " up: " + to_string(mouse_up(RIGHT_BUTTON)) + " down: " + to_string(mouse_down(RIGHT_BUTTON));
         
+        string any_key_input = "Any keys pressed: ";
+        if(any_key_pressed()) any_key_input += "yes";
+        else any_key_input += "no";
+
+
         string key_details = "T key is ";
         if ( key_down(T_KEY) ) key_details += "down";
         if ( key_up(T_KEY) ) key_details += "up";
         if ( key_released(T_KEY) ) key_details += " - released";
         if ( key_typed(T_KEY) ) key_details += " - typed";
+        
+
 
         if ( key_typed(F_KEY) ) window_toggle_fullscreen(window_with_focus());
         if ( key_typed(B_KEY) ) window_toggle_border(window_with_focus());
 
+
         draw_text(location, COLOR_PLUM, "hara", 14, 18, 200);
         draw_text(left_clicked, COLOR_PLUM, "hara", 14, 18, 220);
         draw_text(right_clicked, COLOR_PLUM, "hara", 14, 18, 240);
+        draw_text(any_key_input, COLOR_PLUM, "hara", 14, 18, 250);
         draw_text(key_details, COLOR_PLUM, "hara", 14, 18, 280);
         draw_text(_key_down, COLOR_PLUM, "hara", 14, 18, 300);
         draw_text(_key_up, COLOR_PLUM, "hara", 14, 18, 320);
         draw_text(_key_typed, COLOR_PLUM, "hara", 14, 18, 340);
+        
         
         set_current_window(w2);
         
@@ -122,6 +140,7 @@ void run_input_test()
         draw_text(location, COLOR_PLUM, "hara", 14, 18, 200);
         draw_text(left_clicked, COLOR_PLUM, "hara", 14, 18, 220);
         draw_text(right_clicked, COLOR_PLUM, "hara", 14, 18, 240);
+        draw_text(any_key_input, COLOR_PLUM, "hara", 14, 18, 250);
         draw_text(key_details, COLOR_PLUM, "hara", 14, 18, 280);
         draw_text(_key_down, COLOR_PLUM, "hara", 14, 18, 300);
         draw_text(_key_up, COLOR_PLUM, "hara", 14, 18, 320);
@@ -139,3 +158,6 @@ void run_input_test()
     
     free_all_fonts();
 }
+
+
+```


### PR DESCRIPTION
# Description

I have changed how the any_key_pressed() function works so that it will actually test for keys pressed. Bool is set to true when a key_down event occurs and is back to false when a key is released. splashkit doens't have a great way of keeping track of how many keys have been pressed, so with the way that the function works currently holding down two keys and then releasing one of them will toggle "_any_keys_pressed" back to false. Also had to remove the flag from getting reset in _keyboard_start_process_events() otherwise the bool would be reset at every tick of the program.

Fixes # (issue)
Bug where any_key_pressed() function would always return false regardless of keyboard input.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Tested with sktest & unit tests. All tests pass, keys are detected as expected.  Due to the aforementioned issues with key tracking releasing a single key when multiple keys are held down will toggle this boolean back to false.

## Testing Checklist

- [X] Tested with sktest
- [X] Tested with skunit_tests

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from ... on the Pull Request
