### PR TITLE
Fix vector_magnitude_squared typo

### DIFF
--- a/coresdk/src/coresdk/circle_geometry.cpp
+++ b/coresdk/src/coresdk/circle_geometry.cpp
@@ -174,7 +174,7 @@ namespace splashkit_lib
     {
         vector_2d pm_c = vector_point_to_point(from_pt, c.center);
 
-        double sqr_len = vector_magnitude_sqared(pm_c);
+        double sqr_len = vector_magnitude_squared(pm_c);
         double r_sqr = c.radius * c.radius;
 
         // Quick check for P inside the circle, return False if so

--- a/coresdk/src/coresdk/vector_2d.cpp
+++ b/coresdk/src/coresdk/vector_2d.cpp
@@ -132,14 +132,14 @@ namespace splashkit_lib
         return { -v.y / magnitude, v.x / magnitude };
     }
 
-    double vector_magnitude_sqared(const vector_2d &v)
+    double vector_magnitude_squared(const vector_2d &v)
     {
         return (v.x * v.x) + (v.y * v.y);
     }
 
     double vector_magnitude(const vector_2d &v)
     {
-        return sqrt(vector_magnitude_sqared(v));
+        return sqrt(vector_magnitude_squared(v));
     }
 
     vector_2d vector_limit(const vector_2d &v, double limit)

--- a/coresdk/src/coresdk/vector_2d.h
+++ b/coresdk/src/coresdk/vector_2d.h
@@ -166,7 +166,7 @@ namespace splashkit_lib
      * @param  v The vector
      * @return   Its squared magnitude
      */
-    double vector_magnitude_sqared(const vector_2d &v);
+    double vector_magnitude_squared(const vector_2d &v);
 
     /**
      * Returns the magnitude (or "length") of the vector.


### PR DESCRIPTION
Renames the function `vector_magnitude_sqared` to `vector_magnitude_squared`.

Note: #182 already used the updated name, hence that usage hasn't needed to be updated in this PR. It also means builds would have been broken until this PR was merged.

Original PR: https://github.com/thoth-tech/splashkit-core/pull/62