### PR TITLE
Fix/change label text throughout codebase

### DIFF
--- a/coresdk/src/backend/interface_driver.cpp
+++ b/coresdk/src/backend/interface_driver.cpp
@@ -581,14 +581,14 @@ namespace splashkit_lib
         mu_pop_id(ctx);
     }
 
-    bool sk_interface_header(const string& label)
+    bool sk_interface_header(const string& text_label)
     {
-        return mu_header(ctx, label.c_str());
+        return mu_header(ctx, text_label.c_str());
     }
 
-    void sk_interface_label(const string& label)
+    void sk_interface_label(const string& text_label)
     {
-        mu_label(ctx, label.c_str());
+        mu_label(ctx, text_label.c_str());
     }
 
     void sk_interface_text(const string& text)
@@ -596,18 +596,18 @@ namespace splashkit_lib
         mu_text(ctx, text.c_str());
     }
 
-    bool sk_interface_button(const string& label, int icon)
+    bool sk_interface_button(const string& text_label, int icon)
     {
-        update_elements_changed(mu_button_ex(ctx, label.c_str(), icon, MU_OPT_ALIGNCENTER));
+        update_elements_changed(mu_button_ex(ctx, text_label.c_str(), icon, MU_OPT_ALIGNCENTER));
         return element_confirmed;
     }
 
-    bool sk_interface_checkbox(const string& label, const bool& value)
+    bool sk_interface_checkbox(const string& text_label, const bool& value)
     {
         sk_interface_push_ptr_id((void*)&value);
 
         int temp_value = value;
-        update_elements_changed(mu_checkbox(ctx, label.c_str(), &temp_value));
+        update_elements_changed(mu_checkbox(ctx, text_label.c_str(), &temp_value));
 
         sk_interface_pop_id();
         return temp_value;

--- a/coresdk/src/backend/interface_driver.cpp
+++ b/coresdk/src/backend/interface_driver.cpp
@@ -581,14 +581,14 @@ namespace splashkit_lib
         mu_pop_id(ctx);
     }
 
-    bool sk_interface_header(const string& text_label)
+    bool sk_interface_header(const string& label_text)
     {
-        return mu_header(ctx, text_label.c_str());
+        return mu_header(ctx, label_text.c_str());
     }
 
-    void sk_interface_label(const string& text_label)
+    void sk_interface_label(const string& label_text)
     {
-        mu_label(ctx, text_label.c_str());
+        mu_label(ctx, label_text.c_str());
     }
 
     void sk_interface_text(const string& text)
@@ -596,18 +596,18 @@ namespace splashkit_lib
         mu_text(ctx, text.c_str());
     }
 
-    bool sk_interface_button(const string& text_label, int icon)
+    bool sk_interface_button(const string& label_text, int icon)
     {
-        update_elements_changed(mu_button_ex(ctx, text_label.c_str(), icon, MU_OPT_ALIGNCENTER));
+        update_elements_changed(mu_button_ex(ctx, label_text.c_str(), icon, MU_OPT_ALIGNCENTER));
         return element_confirmed;
     }
 
-    bool sk_interface_checkbox(const string& text_label, const bool& value)
+    bool sk_interface_checkbox(const string& label_text, const bool& value)
     {
         sk_interface_push_ptr_id((void*)&value);
 
         int temp_value = value;
-        update_elements_changed(mu_checkbox(ctx, text_label.c_str(), &temp_value));
+        update_elements_changed(mu_checkbox(ctx, label_text.c_str(), &temp_value));
 
         sk_interface_pop_id();
         return temp_value;

--- a/coresdk/src/backend/interface_driver.h
+++ b/coresdk/src/backend/interface_driver.h
@@ -54,11 +54,11 @@ namespace splashkit_lib
     void sk_interface_push_ptr_id(void* ptr);
     void sk_interface_pop_id();
 
-    bool sk_interface_header(const string& label);
-    void sk_interface_label(const string& label);
+    bool sk_interface_header(const string& text_label);
+    void sk_interface_label(const string& text_label);
     void sk_interface_text(const string& text);
-    bool sk_interface_button(const string& label, int icon);
-    bool sk_interface_checkbox(const string& label, const bool& value);
+    bool sk_interface_button(const string& text_label, int icon);
+    bool sk_interface_checkbox(const string& text_label, const bool& value);
     float sk_interface_slider(const float& value, float min_value, float max_value);
     float sk_interface_number(const float& value, float step);
     std::string sk_interface_text_box(const std::string& value);

--- a/coresdk/src/backend/interface_driver.h
+++ b/coresdk/src/backend/interface_driver.h
@@ -54,11 +54,11 @@ namespace splashkit_lib
     void sk_interface_push_ptr_id(void* ptr);
     void sk_interface_pop_id();
 
-    bool sk_interface_header(const string& text_label);
-    void sk_interface_label(const string& text_label);
+    bool sk_interface_header(const string& label_text);
+    void sk_interface_label(const string& label_text);
     void sk_interface_text(const string& text);
-    bool sk_interface_button(const string& text_label, int icon);
-    bool sk_interface_checkbox(const string& text_label, const bool& value);
+    bool sk_interface_button(const string& label_text, int icon);
+    bool sk_interface_checkbox(const string& label_text, const bool& value);
     float sk_interface_slider(const float& value, float min_value, float max_value);
     float sk_interface_number(const float& value, float step);
     std::string sk_interface_text_box(const std::string& value);

--- a/coresdk/src/coresdk/interface.cpp
+++ b/coresdk/src/coresdk/interface.cpp
@@ -730,16 +730,16 @@ namespace splashkit_lib
         _pop_container_stack(panel_type::column, "");
     }
 
-    bool header(const string& text_label)
+    bool header(const string& label_text)
     {
         _interface_sanity_check();
 
-        bool open = sk_interface_header(text_label);
+        bool open = sk_interface_header(label_text);
 
         return open;
     }
 
-    void text_label(const string& text)
+    void label_element(const string& text)
     {
         _interface_sanity_check();
 
@@ -748,13 +748,13 @@ namespace splashkit_lib
         _update_text_style();
     }
 
-    void text_label(const string& text, const rectangle& rect)
+    void label_element(const string& text, const rectangle& rect)
     {
         _interface_sanity_check();
 
         sk_interface_set_layout_next(rect, true);
 
-        text_label(text);
+        label_element(text);
     }
 
     void paragraph(const string& text, const rectangle& rect)
@@ -774,14 +774,14 @@ namespace splashkit_lib
         _update_text_style();
     }
 
-    bool button(const string& text_label, const string& text)
+    bool button(const string& label_text, const string& text)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::text_label(text_label);
+        splashkit_lib::label_element(label_text);
         bool res = button(text);
 
         leave_column();
@@ -889,14 +889,14 @@ namespace splashkit_lib
         return bitmap_button(bmp, option_defaults());
     }
 
-    bool bitmap_button(const string& text_label, bitmap bmp, drawing_options opts)
+    bool bitmap_button(const string& label_text, bitmap bmp, drawing_options opts)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::text_label(text_label);
+        splashkit_lib::label_element(label_text);
 
         bool res = _bitmap_button_internal(bmp, nullptr, opts);
 
@@ -905,9 +905,9 @@ namespace splashkit_lib
         return res;
     }
 
-    bool bitmap_button(const string& text_label, bitmap bmp)
+    bool bitmap_button(const string& label_text, bitmap bmp)
     {
-        return bitmap_button(text_label, bmp, option_defaults());
+        return bitmap_button(label_text, bmp, option_defaults());
     }
 
     bool bitmap_button(bitmap bmp, const rectangle& rect, drawing_options opts)
@@ -920,14 +920,14 @@ namespace splashkit_lib
         return bitmap_button(bmp, rect, option_defaults());
     }
 
-    bool checkbox(const string& text_label, const string& text, const bool& value)
+    bool checkbox(const string& label_text, const string& text, const bool& value)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::text_label(text_label);
+        splashkit_lib::label_element(label_text);
         bool res = checkbox(text, value);
 
         leave_column();
@@ -954,14 +954,14 @@ namespace splashkit_lib
         return checkbox(text, value);
     }
 
-    float slider(const string& text_label, const float& value, float min_value, float max_value)
+    float slider(const string& label_text, const float& value, float min_value, float max_value)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::text_label(text_label);
+        splashkit_lib::label_element(label_text);
         float res = slider(value, min_value, max_value);
 
         leave_column();
@@ -1046,14 +1046,14 @@ namespace splashkit_lib
         return temp_value;
     }
 
-    color color_slider(const string& text_label, const color& clr)
+    color color_slider(const string& label_text, const color& clr)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::text_label(text_label);
+        splashkit_lib::label_element(label_text);
         color res = color_slider(clr);
 
         leave_column();
@@ -1074,14 +1074,14 @@ namespace splashkit_lib
         return _color_slider(clr, false);
     }
 
-    color hsb_color_slider(const string& text_label, const color& clr)
+    color hsb_color_slider(const string& label_text, const color& clr)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::text_label(text_label);
+        splashkit_lib::label_element(label_text);
         color res = hsb_color_slider(clr);
 
         leave_column();
@@ -1102,14 +1102,14 @@ namespace splashkit_lib
         return _color_slider(clr, true);
     }
 
-    float number_box(const string& text_label, const float& value, float step)
+    float number_box(const string& label_text, const float& value, float step)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::text_label(text_label);
+        splashkit_lib::label_element(label_text);
         float res = number_box(value, step);
 
         leave_column();
@@ -1132,14 +1132,14 @@ namespace splashkit_lib
         return number_box(value, step);
     }
 
-    std::string text_box(const string& text_label, const std::string& value)
+    std::string text_box(const string& label_text, const std::string& value)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::text_label(text_label);
+        splashkit_lib::label_element(label_text);
         std::string res = text_box(value);
 
         leave_column();

--- a/coresdk/src/coresdk/interface.cpp
+++ b/coresdk/src/coresdk/interface.cpp
@@ -730,16 +730,16 @@ namespace splashkit_lib
         _pop_container_stack(panel_type::column, "");
     }
 
-    bool header(const string& label)
+    bool header(const string& text_label)
     {
         _interface_sanity_check();
 
-        bool open = sk_interface_header(label);
+        bool open = sk_interface_header(text_label);
 
         return open;
     }
 
-    void label(const string& text)
+    void text_label(const string& text)
     {
         _interface_sanity_check();
 
@@ -748,13 +748,13 @@ namespace splashkit_lib
         _update_text_style();
     }
 
-    void label(const string& text, const rectangle& rect)
+    void text_label(const string& text, const rectangle& rect)
     {
         _interface_sanity_check();
 
         sk_interface_set_layout_next(rect, true);
 
-        label(text);
+        text_label(text);
     }
 
     void paragraph(const string& text, const rectangle& rect)
@@ -774,14 +774,14 @@ namespace splashkit_lib
         _update_text_style();
     }
 
-    bool button(const string& label, const string& text)
+    bool button(const string& text_label, const string& text)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::label(label);
+        splashkit_lib::text_label(text_label);
         bool res = button(text);
 
         leave_column();
@@ -889,14 +889,14 @@ namespace splashkit_lib
         return bitmap_button(bmp, option_defaults());
     }
 
-    bool bitmap_button(const string& label, bitmap bmp, drawing_options opts)
+    bool bitmap_button(const string& text_label, bitmap bmp, drawing_options opts)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::label(label);
+        splashkit_lib::text_label(text_label);
 
         bool res = _bitmap_button_internal(bmp, nullptr, opts);
 
@@ -905,9 +905,9 @@ namespace splashkit_lib
         return res;
     }
 
-    bool bitmap_button(const string& label, bitmap bmp)
+    bool bitmap_button(const string& text_label, bitmap bmp)
     {
-        return bitmap_button(label, bmp, option_defaults());
+        return bitmap_button(text_label, bmp, option_defaults());
     }
 
     bool bitmap_button(bitmap bmp, const rectangle& rect, drawing_options opts)
@@ -920,14 +920,14 @@ namespace splashkit_lib
         return bitmap_button(bmp, rect, option_defaults());
     }
 
-    bool checkbox(const string& label, const string& text, const bool& value)
+    bool checkbox(const string& text_label, const string& text, const bool& value)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::label(label);
+        splashkit_lib::text_label(text_label);
         bool res = checkbox(text, value);
 
         leave_column();
@@ -954,14 +954,14 @@ namespace splashkit_lib
         return checkbox(text, value);
     }
 
-    float slider(const string& label, const float& value, float min_value, float max_value)
+    float slider(const string& text_label, const float& value, float min_value, float max_value)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::label(label);
+        splashkit_lib::text_label(text_label);
         float res = slider(value, min_value, max_value);
 
         leave_column();
@@ -1046,14 +1046,14 @@ namespace splashkit_lib
         return temp_value;
     }
 
-    color color_slider(const string& label, const color& clr)
+    color color_slider(const string& text_label, const color& clr)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::label(label);
+        splashkit_lib::text_label(text_label);
         color res = color_slider(clr);
 
         leave_column();
@@ -1074,14 +1074,14 @@ namespace splashkit_lib
         return _color_slider(clr, false);
     }
 
-    color hsb_color_slider(const string& label, const color& clr)
+    color hsb_color_slider(const string& text_label, const color& clr)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::label(label);
+        splashkit_lib::text_label(text_label);
         color res = hsb_color_slider(clr);
 
         leave_column();
@@ -1102,14 +1102,14 @@ namespace splashkit_lib
         return _color_slider(clr, true);
     }
 
-    float number_box(const string& label, const float& value, float step)
+    float number_box(const string& text_label, const float& value, float step)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::label(label);
+        splashkit_lib::text_label(text_label);
         float res = number_box(value, step);
 
         leave_column();
@@ -1132,14 +1132,14 @@ namespace splashkit_lib
         return number_box(value, step);
     }
 
-    std::string text_box(const string& label, const std::string& value)
+    std::string text_box(const string& text_label, const std::string& value)
     {
         _interface_sanity_check();
 
         enter_column();
         _two_column_layout();
 
-        splashkit_lib::label(label);
+        splashkit_lib::text_label(text_label);
         std::string res = text_box(value);
 
         leave_column();

--- a/coresdk/src/coresdk/interface.h
+++ b/coresdk/src/coresdk/interface.h
@@ -169,14 +169,14 @@ namespace splashkit_lib
      * @param label             The name of the node
      * @return                  Whether the tree node is expanded or not
      */
-    bool start_treenode(const string& label);
+    bool start_treenode(const string& text_label);
 
     /**
      * Finishes the creation of a tree node.
      *
      * @param label             The node's name - must match with `start_treenode`
      */
-    void end_treenode(const string& label);
+    void end_treenode(const string& text_label);
 
     /**
      * Makes the popup named `name` open/popup at the cursor's position.
@@ -284,14 +284,14 @@ namespace splashkit_lib
      * @param label             The label to show in the header
      * @return                  Whether the header is expanded or not
      */
-    bool header(const string& label);
+    bool header(const string& text_label);
 
     /**
      * Creates a label with the given text.
      *
      * @param text             The label to show
      */
-    void label(const string& text);
+    void text_label(const string& text);
 
     /**
      * Creates a label at a specific position on screen.
@@ -301,7 +301,7 @@ namespace splashkit_lib
      *
      * @attribute suffix        at_position
      */
-    void label(const string& text, const rectangle& rect);
+    void text_label(const string& text, const rectangle& rect);
 
     /**
      * Creates a paragraph of text that auto-wraps.
@@ -339,7 +339,7 @@ namespace splashkit_lib
      *
      * @attribute suffix        labeled
      */
-    bool button(const string& label, const string& text);
+    bool button(const string& text_label, const string& text);
 
     /**
      * Creates a button without a label.
@@ -372,7 +372,7 @@ namespace splashkit_lib
      *
      * @attribute suffix        labeled
      */
-    bool bitmap_button(const string& label, bitmap bmp);
+    bool bitmap_button(const string& text_label, bitmap bmp);
 
     /**
      * Creates a button with a bitmap in it and a label.
@@ -385,7 +385,7 @@ namespace splashkit_lib
      *
      * @attribute suffix        labeled_with_options
      */
-    bool bitmap_button(const string& label, bitmap bmp, drawing_options opts);
+    bool bitmap_button(const string& text_label, bitmap bmp, drawing_options opts);
 
     /**
      * Creates a button with a bitmap in it, and no label.
@@ -450,7 +450,7 @@ namespace splashkit_lib
      *
      * @attribute suffix        labeled
      */
-    bool checkbox(const string& label, const string& text, const bool& value);
+    bool checkbox(const string& text_label, const string& text, const bool& value);
 
     /**
      * Creates a checkbox.
@@ -492,7 +492,7 @@ namespace splashkit_lib
      *
      * @attribute suffix        labeled
      */
-    float slider(const string& label, const float& value, float min_value, float max_value);
+    float slider(const string& text_label, const float& value, float min_value, float max_value);
 
     /**
      * Creates a slider without a label.
@@ -534,7 +534,7 @@ namespace splashkit_lib
      *
      * @attribute suffix        labeled
      */
-    color color_slider(const string& label, const color& clr);
+    color color_slider(const string& text_label, const color& clr);
 
     /**
      * Creates a set of RGBA sliders to adjust a color.
@@ -572,7 +572,7 @@ namespace splashkit_lib
      *
      * @attribute suffix        labeled
      */
-    color hsb_color_slider(const string& label, const color& clr);
+    color hsb_color_slider(const string& text_label, const color& clr);
 
     /**
      * Creates a set of HSBA (hue, saturation, brightness, alpha) sliders to adjust a color.
@@ -611,7 +611,7 @@ namespace splashkit_lib
      *
      * @attribute suffix        labeled
      */
-    float number_box(const string& label, const float& value, float step);
+    float number_box(const string& text_label, const float& value, float step);
 
     /**
      * Creates a number entry box with a label.
@@ -651,7 +651,7 @@ namespace splashkit_lib
      *
      * @attribute suffix        labeled
      */
-    string text_box(const string& label, const string& value);
+    string text_box(const string& text_label, const string& value);
 
     /**
      * Creates a text entry box at a specific position on screen.

--- a/coresdk/src/coresdk/interface.h
+++ b/coresdk/src/coresdk/interface.h
@@ -166,7 +166,7 @@ namespace splashkit_lib
      * The function **must** be accompanied by a call to `end_treenode`
      * with the same name.
      *
-     * @param label             The name of the node
+     * @param text_label        The name of the node
      * @return                  Whether the tree node is expanded or not
      */
     bool start_treenode(const string& text_label);
@@ -174,7 +174,7 @@ namespace splashkit_lib
     /**
      * Finishes the creation of a tree node.
      *
-     * @param label             The node's name - must match with `start_treenode`
+     * @param text_label        The node's name - must match with `start_treenode`
      */
     void end_treenode(const string& text_label);
 
@@ -281,7 +281,7 @@ namespace splashkit_lib
      * }
      * ```
      *
-     * @param label             The label to show in the header
+     * @param text_label        The label to show in the header
      * @return                  Whether the header is expanded or not
      */
     bool header(const string& text_label);
@@ -297,7 +297,7 @@ namespace splashkit_lib
      * Creates a label at a specific position on screen.
      *
      * @param text             The label to show
-     * @param rect              The rectangle to display the label in
+     * @param rect             The rectangle to display the label in
      *
      * @attribute suffix        at_position
      */
@@ -333,7 +333,7 @@ namespace splashkit_lib
      * }
      * ```
      *
-     * @param label             The label to show in front of the button
+     * @param text_label        The label to show in front of the button
      * @param text              The text to show inside the button
      * @return                  Whether the button was clicked
      *
@@ -366,7 +366,7 @@ namespace splashkit_lib
      * Creates a button with a bitmap in it and a label.
      * Returns whether the button was clicked.
      *
-     * @param label             The label to show in front of the button
+     * @param text_label        The label to show in front of the button
      * @param bmp               The bitmap to show inside the button
      * @return                  Whether the button was clicked
      *
@@ -378,7 +378,7 @@ namespace splashkit_lib
      * Creates a button with a bitmap in it and a label.
      * Returns whether the button was clicked.
      *
-     * @param label             The label to show in front of the button
+     * @param text_label        The label to show in front of the button
      * @param bmp               The bitmap to show inside the button
      * @param opts              The drawing options
      * @return                  Whether the button was clicked
@@ -443,7 +443,7 @@ namespace splashkit_lib
      * my_bool = checkbox("Checkbox 1", "Enabled?", my_bool);
      * ```
      *
-     * @param label             The label to show in front of the checkbox
+     * @param text_label        The label to show in front of the checkbox
      * @param text              The text to show next to the checkbox
      * @param value             The current value of the checkbox
      * @return                  The updated value of the checkbox
@@ -484,7 +484,7 @@ namespace splashkit_lib
      * my_float = slider("Percentage", my_float, 0, 100);
      * ```
      *
-     * @param label             The label to show in front of the slider
+     * @param text_label        The label to show in front of the slider
      * @param value             The current value of the slider
      * @param min_value         The minimum value of the slider
      * @param max_value         The maximum value of the slider
@@ -528,7 +528,7 @@ namespace splashkit_lib
      * my_color = color_slider("Player Color", my_color);
      * ```
      *
-     * @param label             The label to show in front of the slider
+     * @param text_label        The label to show in front of the slider
      * @param clr               The current value of the color slider
      * @return                  The updated value of the slider
      *
@@ -566,7 +566,7 @@ namespace splashkit_lib
      * my_color = hsb_color_slider("Player Color", my_color);
      * ```
      *
-     * @param label             The label to show in front of the slider
+     * @param text_label        The label to show in front of the slider
      * @param clr               The current value of the color slider
      * @return                  The updated value of the slider
      *
@@ -604,7 +604,7 @@ namespace splashkit_lib
      * my_float = number_box("Percentage", my_float, 1);
      * ```
      *
-     * @param label             The label to show in front of the number box
+     * @param text_label        The label to show in front of the number box
      * @param value             The current value of the number box
      * @param step              The amount incremented when dragging on the box
      * @return                  The updated value of the slider
@@ -645,7 +645,7 @@ namespace splashkit_lib
      * my_string = text_box("Name", my_string);
      * ```
      *
-     * @param label             The label to show in front of the text box
+     * @param text_label        The label to show in front of the text box
      * @param value             The current value of the text box
      * @return                  The updated value of the text box
      *

--- a/coresdk/src/coresdk/interface.h
+++ b/coresdk/src/coresdk/interface.h
@@ -166,17 +166,17 @@ namespace splashkit_lib
      * The function **must** be accompanied by a call to `end_treenode`
      * with the same name.
      *
-     * @param text_label        The name of the node
+     * @param label_text        The name of the node
      * @return                  Whether the tree node is expanded or not
      */
-    bool start_treenode(const string& text_label);
+    bool start_treenode(const string& label_text);
 
     /**
      * Finishes the creation of a tree node.
      *
-     * @param text_label        The node's name - must match with `start_treenode`
+     * @param label_text        The node's name - must match with `start_treenode`
      */
-    void end_treenode(const string& text_label);
+    void end_treenode(const string& label_text);
 
     /**
      * Makes the popup named `name` open/popup at the cursor's position.
@@ -281,17 +281,17 @@ namespace splashkit_lib
      * }
      * ```
      *
-     * @param text_label        The label to show in the header
+     * @param label_text        The label to show in the header
      * @return                  Whether the header is expanded or not
      */
-    bool header(const string& text_label);
+    bool header(const string& label_text);
 
     /**
      * Creates a label with the given text.
      *
      * @param text             The label to show
      */
-    void text_label(const string& text);
+    void label_element(const string& text);
 
     /**
      * Creates a label at a specific position on screen.
@@ -301,7 +301,7 @@ namespace splashkit_lib
      *
      * @attribute suffix        at_position
      */
-    void text_label(const string& text, const rectangle& rect);
+    void label_element(const string& text, const rectangle& rect);
 
     /**
      * Creates a paragraph of text that auto-wraps.
@@ -333,13 +333,13 @@ namespace splashkit_lib
      * }
      * ```
      *
-     * @param text_label        The label to show in front of the button
+     * @param label_text        The label to show in front of the button
      * @param text              The text to show inside the button
      * @return                  Whether the button was clicked
      *
      * @attribute suffix        labeled
      */
-    bool button(const string& text_label, const string& text);
+    bool button(const string& label_text, const string& text);
 
     /**
      * Creates a button without a label.
@@ -366,26 +366,26 @@ namespace splashkit_lib
      * Creates a button with a bitmap in it and a label.
      * Returns whether the button was clicked.
      *
-     * @param text_label        The label to show in front of the button
+     * @param label_text        The label to show in front of the button
      * @param bmp               The bitmap to show inside the button
      * @return                  Whether the button was clicked
      *
      * @attribute suffix        labeled
      */
-    bool bitmap_button(const string& text_label, bitmap bmp);
+    bool bitmap_button(const string& label_text, bitmap bmp);
 
     /**
      * Creates a button with a bitmap in it and a label.
      * Returns whether the button was clicked.
      *
-     * @param text_label        The label to show in front of the button
+     * @param label_text        The label to show in front of the button
      * @param bmp               The bitmap to show inside the button
      * @param opts              The drawing options
      * @return                  Whether the button was clicked
      *
      * @attribute suffix        labeled_with_options
      */
-    bool bitmap_button(const string& text_label, bitmap bmp, drawing_options opts);
+    bool bitmap_button(const string& label_text, bitmap bmp, drawing_options opts);
 
     /**
      * Creates a button with a bitmap in it, and no label.
@@ -443,14 +443,14 @@ namespace splashkit_lib
      * my_bool = checkbox("Checkbox 1", "Enabled?", my_bool);
      * ```
      *
-     * @param text_label        The label to show in front of the checkbox
+     * @param label_text        The label to show in front of the checkbox
      * @param text              The text to show next to the checkbox
      * @param value             The current value of the checkbox
      * @return                  The updated value of the checkbox
      *
      * @attribute suffix        labeled
      */
-    bool checkbox(const string& text_label, const string& text, const bool& value);
+    bool checkbox(const string& label_text, const string& text, const bool& value);
 
     /**
      * Creates a checkbox.
@@ -484,7 +484,7 @@ namespace splashkit_lib
      * my_float = slider("Percentage", my_float, 0, 100);
      * ```
      *
-     * @param text_label        The label to show in front of the slider
+     * @param label_text        The label to show in front of the slider
      * @param value             The current value of the slider
      * @param min_value         The minimum value of the slider
      * @param max_value         The maximum value of the slider
@@ -492,7 +492,7 @@ namespace splashkit_lib
      *
      * @attribute suffix        labeled
      */
-    float slider(const string& text_label, const float& value, float min_value, float max_value);
+    float slider(const string& label_text, const float& value, float min_value, float max_value);
 
     /**
      * Creates a slider without a label.
@@ -528,13 +528,13 @@ namespace splashkit_lib
      * my_color = color_slider("Player Color", my_color);
      * ```
      *
-     * @param text_label        The label to show in front of the slider
+     * @param label_text        The label to show in front of the slider
      * @param clr               The current value of the color slider
      * @return                  The updated value of the slider
      *
      * @attribute suffix        labeled
      */
-    color color_slider(const string& text_label, const color& clr);
+    color color_slider(const string& label_text, const color& clr);
 
     /**
      * Creates a set of RGBA sliders to adjust a color.
@@ -566,13 +566,13 @@ namespace splashkit_lib
      * my_color = hsb_color_slider("Player Color", my_color);
      * ```
      *
-     * @param text_label        The label to show in front of the slider
+     * @param label_text        The label to show in front of the slider
      * @param clr               The current value of the color slider
      * @return                  The updated value of the slider
      *
      * @attribute suffix        labeled
      */
-    color hsb_color_slider(const string& text_label, const color& clr);
+    color hsb_color_slider(const string& label_text, const color& clr);
 
     /**
      * Creates a set of HSBA (hue, saturation, brightness, alpha) sliders to adjust a color.
@@ -604,14 +604,14 @@ namespace splashkit_lib
      * my_float = number_box("Percentage", my_float, 1);
      * ```
      *
-     * @param text_label        The label to show in front of the number box
+     * @param label_text        The label to show in front of the number box
      * @param value             The current value of the number box
      * @param step              The amount incremented when dragging on the box
      * @return                  The updated value of the slider
      *
      * @attribute suffix        labeled
      */
-    float number_box(const string& text_label, const float& value, float step);
+    float number_box(const string& label_text, const float& value, float step);
 
     /**
      * Creates a number entry box with a label.
@@ -645,13 +645,13 @@ namespace splashkit_lib
      * my_string = text_box("Name", my_string);
      * ```
      *
-     * @param text_label        The label to show in front of the text box
+     * @param label_text        The label to show in front of the text box
      * @param value             The current value of the text box
      * @return                  The updated value of the text box
      *
      * @attribute suffix        labeled
      */
-    string text_box(const string& text_label, const string& value);
+    string text_box(const string& label_text, const string& value);
 
     /**
      * Creates a text entry box at a specific position on screen.

--- a/coresdk/src/test/test_ui.cpp
+++ b/coresdk/src/test/test_ui.cpp
@@ -78,7 +78,7 @@ void run_ui_test()
                 add_column(60);
                 add_column(-1);
 
-                text_label("Second:");
+                label_element("Second:");
                 // Draw second label + button
                 if (button("Button2"))
                 {
@@ -112,13 +112,13 @@ void run_ui_test()
                 set_interface_font(fontB);
                 set_interface_font_size(14);
 
-                text_label("Hi world!");
+                label_element("Hi world!");
 
                 // Switch back to the original font for
                 // second label.
                 set_interface_font(fontA);
 
-                text_label("Hello world!");
+                label_element("Hello world!");
 
                 // Reset text size
                 set_interface_font_size(12);
@@ -158,7 +158,7 @@ void run_ui_test()
 
             // Show if the window is currently reading text,
             // useful for testing that behaviour.
-            text_label("Is reading text: " + (std::string)(reading_text()?"Yea":"Nay"));
+            label_element("Is reading text: " + (std::string)(reading_text()?"Yea":"Nay"));
             end_panel("My Window");
         }
 

--- a/coresdk/src/test/test_ui.cpp
+++ b/coresdk/src/test/test_ui.cpp
@@ -78,7 +78,7 @@ void run_ui_test()
                 add_column(60);
                 add_column(-1);
 
-                label("Second:");
+                text_label("Second:");
                 // Draw second label + button
                 if (button("Button2"))
                 {
@@ -112,13 +112,13 @@ void run_ui_test()
                 set_interface_font(fontB);
                 set_interface_font_size(14);
 
-                label("Hi world!");
+                text_label("Hi world!");
 
                 // Switch back to the original font for
                 // second label.
                 set_interface_font(fontA);
 
-                label("Hello world!");
+                text_label("Hello world!");
 
                 // Reset text size
                 set_interface_font_size(12);
@@ -158,7 +158,7 @@ void run_ui_test()
 
             // Show if the window is currently reading text,
             // useful for testing that behaviour.
-            label("Is reading text: " + (std::string)(reading_text()?"Yea":"Nay"));
+            text_label("Is reading text: " + (std::string)(reading_text()?"Yea":"Nay"));
             end_panel("My Window");
         }
 


### PR DESCRIPTION
Renames `label(...)` to `label_element(...)`, and all other instances of `label` to `label_text`.

This is done to help with supporting Pascal, for which `label` is a keyword.

Original PR with more details: https://github.com/thoth-tech/splashkit-core/pull/66