### PR TITLE
Fix newtext parameter case/name

### DIFF
--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -74,7 +74,7 @@ namespace splashkit_lib
         return static_cast<int>(pos);
     }
 
-    string replace_all(const string &text, const string &substr, const string &replacement)
+    string replace_all(const string &text, const string &substr, const string &newtext)
     {
         if (substr.empty())
             return text;
@@ -83,8 +83,8 @@ namespace splashkit_lib
         size_t pos = 0;
         while ((pos = result.find(substr, pos)) != string::npos)
         {
-            result.replace(pos, substr.length(), replacement);
-            pos += replacement.length();
+            result.replace(pos, substr.length(), newtext);
+            pos += newtext.length();
         }
         return result;
     }

--- a/coresdk/src/coresdk/basics.h
+++ b/coresdk/src/coresdk/basics.h
@@ -122,10 +122,10 @@ namespace splashkit_lib
      * 
      * @param text      The text to search
      * @param substr    The substring to find and replace
-     * @param newText   The string to replace the substring with
+     * @param newtext   The string to replace the substring with
      * @returns         The text with all occurrences of the substring replaced with the new text.
      */
-    string replace_all(const string &text, const string &substr, const string &newText);
+    string replace_all(const string &text, const string &substr, const string &newtext);
 
     /**
      * Split a string into an array of strings based on a delimiter.

--- a/generated/clib/sk_clib.cpp
+++ b/generated/clib/sk_clib.cpp
@@ -259,11 +259,11 @@ int __sklib__length_of__string_ref(const __sklib_string text) {
     int __skreturn = length_of(__skparam__text);
     return __sklib__to_int(__skreturn);
 }
-__sklib_string __sklib__replace_all__string_ref__string_ref__string_ref(const __sklib_string text, const __sklib_string substr, const __sklib_string newText) {
+__sklib_string __sklib__replace_all__string_ref__string_ref__string_ref(const __sklib_string text, const __sklib_string substr, const __sklib_string newtext) {
     string __skparam__text = __sklib__to_string(text);
     string __skparam__substr = __sklib__to_string(substr);
-    string __skparam__newText = __sklib__to_string(newText);
-    string __skreturn = replace_all(__skparam__text, __skparam__substr, __skparam__newText);
+    string __skparam__newtext = __sklib__to_string(newtext);
+    string __skreturn = replace_all(__skparam__text, __skparam__substr, __skparam__newtext);
     return __sklib__to_sklib_string(__skreturn);
 }
 __sklib_vector_string __sklib__split__string_ref__char(const __sklib_string text, char delimiter) {

--- a/generated/clib/sk_clib.h
+++ b/generated/clib/sk_clib.h
@@ -219,7 +219,7 @@ int __sklib__is_double__string_ref(const __sklib_string text);
 int __sklib__is_integer__string_ref(const __sklib_string text);
 int __sklib__is_number__string_ref(const __sklib_string text);
 int __sklib__length_of__string_ref(const __sklib_string text);
-__sklib_string __sklib__replace_all__string_ref__string_ref__string_ref(const __sklib_string text, const __sklib_string substr, const __sklib_string newText);
+__sklib_string __sklib__replace_all__string_ref__string_ref__string_ref(const __sklib_string text, const __sklib_string substr, const __sklib_string newtext);
 __sklib_vector_string __sklib__split__string_ref__char(const __sklib_string text, char delimiter);
 __sklib_string __sklib__to_lowercase__string_ref(const __sklib_string text);
 __sklib_string __sklib__to_uppercase__string_ref(const __sklib_string text);

--- a/generated/cpp/basics.h
+++ b/generated/cpp/basics.h
@@ -20,7 +20,7 @@ bool is_double(const string &text);
 bool is_integer(const string &text);
 bool is_number(const string &text);
 int length_of(const string &text);
-string replace_all(const string &text, const string &substr, const string &newText);
+string replace_all(const string &text, const string &substr, const string &newtext);
 vector<string> split(const string &text, char delimiter);
 string to_lowercase(const string &text);
 string to_uppercase(const string &text);

--- a/generated/cpp/splashkit.cpp
+++ b/generated/cpp/splashkit.cpp
@@ -291,14 +291,14 @@ int length_of(const string &text) {
     __skadapter__free__sklib_string(__skparam__text);
     return __skadapter__to_int(__skreturn);
 }
-string replace_all(const string &text, const string &substr, const string &newText) {
+string replace_all(const string &text, const string &substr, const string &newtext) {
     const __sklib_string __skparam__text = __skadapter__to_sklib_string(text);
     const __sklib_string __skparam__substr = __skadapter__to_sklib_string(substr);
-    const __sklib_string __skparam__newText = __skadapter__to_sklib_string(newText);
-    __sklib_string __skreturn = __sklib__replace_all__string_ref__string_ref__string_ref(__skparam__text, __skparam__substr, __skparam__newText);
+    const __sklib_string __skparam__newtext = __skadapter__to_sklib_string(newtext);
+    __sklib_string __skreturn = __sklib__replace_all__string_ref__string_ref__string_ref(__skparam__text, __skparam__substr, __skparam__newtext);
     __skadapter__free__sklib_string(__skparam__text);
     __skadapter__free__sklib_string(__skparam__substr);
-    __skadapter__free__sklib_string(__skparam__newText);
+    __skadapter__free__sklib_string(__skparam__newtext);
     return __skadapter__to_string(__skreturn);
 }
 vector<string> split(const string &text, char delimiter) {

--- a/generated/csharp/SplashKit.cs
+++ b/generated/csharp/SplashKit.cs
@@ -5239,15 +5239,15 @@ namespace SplashKitSDK
     {
       __sklib_string __skparam__text;
       __sklib_string __skparam__substr;
-      __sklib_string __skparam__newText;
+      __sklib_string __skparam__newtext;
       __sklib_string __skreturn;
       __skparam__text = __skadapter__to_sklib_string(text);
       __skparam__substr = __skadapter__to_sklib_string(substr);
-      __skparam__newText = __skadapter__to_sklib_string(newtext);
-      __skreturn = __sklib__replace_all__string_ref__string_ref__string_ref(__skparam__text, __skparam__substr, __skparam__newText);
+      __skparam__newtext = __skadapter__to_sklib_string(newtext);
+      __skreturn = __sklib__replace_all__string_ref__string_ref__string_ref(__skparam__text, __skparam__substr, __skparam__newtext);
     __skadapter__free__sklib_string(ref __skparam__text);
     __skadapter__free__sklib_string(ref __skparam__substr);
-    __skadapter__free__sklib_string(ref __skparam__newText);
+    __skadapter__free__sklib_string(ref __skparam__newtext);
       return __skadapter__to_string(__skreturn);
     }
     public static List<string> Split(string text, char delimiter)

--- a/generated/docs/api.json
+++ b/generated/docs/api.json
@@ -86995,7 +86995,7 @@
         }
       },
       {
-        "signature": "string replace_all(const string &text,const string &substr,const string &newText);",
+        "signature": "string replace_all(const string &text,const string &substr,const string &newtext);",
         "name": "replace_all",
         "method_name": null,
         "unique_global_name": "replace_all",
@@ -87038,7 +87038,7 @@
             "is_vector": false,
             "type_parameter": null
           },
-          "newText": {
+          "newtext": {
             "type": "string",
             "description": "The string to replace the substring with",
             "is_pointer": false,
@@ -87058,10 +87058,10 @@
         },
         "signatures": {
           "cpp": [
-            "string replace_all(const string &text, const string &substr, const string &newText)"
+            "string replace_all(const string &text, const string &substr, const string &newtext)"
           ],
           "python": [
-            "def replace_all(text, substr, newText):"
+            "def replace_all(text, substr, newtext):"
           ],
           "pascal": [
             "function ReplaceAll(const text: String; const substr: String; const newtext: String): String"

--- a/generated/pascal/splashkit.pas
+++ b/generated/pascal/splashkit.pas
@@ -4318,13 +4318,13 @@ function ReplaceAll(const text: String; const substr: String; const newtext: Str
 var
   __skparam__text: __sklib_string;
   __skparam__substr: __sklib_string;
-  __skparam__newText: __sklib_string;
+  __skparam__newtext: __sklib_string;
   __skreturn: __sklib_string;
 begin
   __skparam__text := __skadapter__to_sklib_string(text);
   __skparam__substr := __skadapter__to_sklib_string(substr);
-  __skparam__newText := __skadapter__to_sklib_string(newtext);
-  __skreturn := __sklib__replace_all__string_ref__string_ref__string_ref(__skparam__text, __skparam__substr, __skparam__newText);
+  __skparam__newtext := __skadapter__to_sklib_string(newtext);
+  __skreturn := __sklib__replace_all__string_ref__string_ref__string_ref(__skparam__text, __skparam__substr, __skparam__newtext);
   result := __skadapter__to_string(__skreturn);
 end;
 function Split(const text: String; delimiter: Char): ArrayOfString;

--- a/generated/python/splashkit.py
+++ b/generated/python/splashkit.py
@@ -4106,11 +4106,11 @@ def length_of ( text ):
     __skparam__text = __skadapter__to_sklib_string(text)
     __skreturn = sklib.__sklib__length_of__string_ref(__skparam__text)
     return __skadapter__to_int(__skreturn)
-def replace_all ( text, substr, newText ):
+def replace_all ( text, substr, newtext ):
     __skparam__text = __skadapter__to_sklib_string(text)
     __skparam__substr = __skadapter__to_sklib_string(substr)
-    __skparam__newText = __skadapter__to_sklib_string(newtext)
-    __skreturn = sklib.__sklib__replace_all__string_ref__string_ref__string_ref(__skparam__text, __skparam__substr, __skparam__newText)
+    __skparam__newtext = __skadapter__to_sklib_string(newtext)
+    __skreturn = sklib.__sklib__replace_all__string_ref__string_ref__string_ref(__skparam__text, __skparam__substr, __skparam__newtext)
     return __skadapter__to_string(__skreturn)
 def split ( text, delimiter ):
     __skparam__text = __skadapter__to_sklib_string(text)

--- a/generated/translator_cache.json
+++ b/generated/translator_cache.json
@@ -3,7 +3,7 @@
     "group": "animations",
     "brief": "Animations in SplashKit can be used to move between cells in\nbitmaps and sprites. Each animation generates a number sequence\nthat can then be used when drawing bitmaps.",
     "description": null,
-    "parsed_at": 1720129611,
+    "parsed_at": 1731922863,
     "path": "coresdk/src/coresdk/animations.h",
     "functions": [
       {
@@ -1951,7 +1951,7 @@
     "group": "audio",
     "brief": "SplashKit Audio allows you to load and play music and sound effects.",
     "description": "SplashKit's audio library allows you to easily load and play music and\nsound effects within your programs. To get started with audio the first\nthing you need to do is load a sound effect or music file. You can do this\nby calling the `load_sound_effect(string name)` function to the\n`load_music(string name)` function.",
-    "parsed_at": 1720129612,
+    "parsed_at": 1731922864,
     "path": "coresdk/src/coresdk/audio.h",
     "functions": [
       {
@@ -2045,7 +2045,7 @@
     "group": "utilities",
     "brief": "SplashKit provides some basic data manipulation functions to\nhelp make it easy to get some basic tasks performed.",
     "description": null,
-    "parsed_at": 1720129614,
+    "parsed_at": 1731922864,
     "path": "coresdk/src/coresdk/basics.h",
     "functions": [
       {
@@ -2371,7 +2371,7 @@
         }
       },
       {
-        "signature": "string replace_all(const string &text,const string &substr,const string &newText);",
+        "signature": "string replace_all(const string &text,const string &substr,const string &newtext);",
         "name": "replace_all",
         "method_name": null,
         "unique_global_name": "replace_all",
@@ -2414,7 +2414,7 @@
             "is_vector": false,
             "type_parameter": null
           },
-          "newText": {
+          "newtext": {
             "type": "string",
             "description": "The string to replace the substring with",
             "is_pointer": false,
@@ -2612,7 +2612,7 @@
     "group": "resource_bundles",
     "brief": "SplashKit resource bundles allow you to quickly and easily load a\nnumber of resources in the `Resources` folder.",
     "description": "Supports the loading and freeing of game resource bundles. Resource types\ninclude images, sounds, music and animation files to name a few. Resource\nfiles must be saved in specific locations of a `Resources` folder for\nyour game.",
-    "parsed_at": 1720129615,
+    "parsed_at": 1731922864,
     "path": "coresdk/src/coresdk/bundles.h",
     "functions": [
       {
@@ -2757,7 +2757,7 @@
     "group": "camera",
     "brief": "SplashKit camera functionality allows you to move a virtual camera\naround in your world.",
     "description": "Splashkit camera functionality allows you to move a virtual camera around in\nyour world. This camera projects to the users window, allowing you to\ndraw things to the screen in your world coordinates.",
-    "parsed_at": 1720129618,
+    "parsed_at": 1731922865,
     "path": "coresdk/src/coresdk/camera.h",
     "functions": [
       {
@@ -3824,7 +3824,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129623,
+    "parsed_at": 1731922865,
     "path": "coresdk/src/coresdk/circle_drawing.h",
     "functions": [
       {
@@ -5195,7 +5195,7 @@
     "group": "geometry",
     "brief": null,
     "description": null,
-    "parsed_at": 1729338084,
+    "parsed_at": 1731922865,
     "path": "coresdk/src/coresdk/circle_geometry.h",
     "functions": [
       {
@@ -6286,7 +6286,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129628,
+    "parsed_at": 1731922866,
     "path": "coresdk/src/coresdk/clipping.h",
     "functions": [
       {
@@ -6870,7 +6870,7 @@
     "group": "physics",
     "brief": "SplashKit Collisions library allow you to perform tests between\nbitmaps, sprites and shapes to determin if a collision has occured.",
     "description": null,
-    "parsed_at": 1720129634,
+    "parsed_at": 1731922867,
     "path": "coresdk/src/coresdk/collisions.h",
     "functions": [
       {
@@ -9121,7 +9121,7 @@
     "group": "color",
     "brief": "SplashKit simplifies color manipulation in graphical applications for developers, ensuring ease of use and efficiency.",
     "description": null,
-    "parsed_at": 1720129659,
+    "parsed_at": 1731922869,
     "path": "coresdk/src/coresdk/color.h",
     "functions": [
       {
@@ -14321,7 +14321,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129664,
+    "parsed_at": 1731922870,
     "path": "coresdk/src/coresdk/drawing_options.h",
     "functions": [
       {
@@ -15685,7 +15685,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129670,
+    "parsed_at": 1731922870,
     "path": "coresdk/src/coresdk/ellipse_drawing.h",
     "functions": [
       {
@@ -17780,7 +17780,7 @@
     "group": "geometry",
     "brief": "SplashKit's geometry functions assist with geometry-related computations.",
     "description": null,
-    "parsed_at": 1720129671,
+    "parsed_at": 1731922871,
     "path": "coresdk/src/coresdk/geometry.h",
     "functions": [
       {
@@ -17912,7 +17912,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129673,
+    "parsed_at": 1731922871,
     "path": "coresdk/src/coresdk/graphics.h",
     "functions": [
       {
@@ -18488,7 +18488,7 @@
     "group": "graphics",
     "brief": "SplashKit Images allow drawing of bitmaps and sprites to graphic windows.",
     "description": null,
-    "parsed_at": 1720129680,
+    "parsed_at": 1731922872,
     "path": "coresdk/src/coresdk/images.h",
     "functions": [
       {
@@ -21013,7 +21013,7 @@
     "group": "input",
     "brief": "Input handles user interaction and events such as keypresses.",
     "description": null,
-    "parsed_at": 1720129681,
+    "parsed_at": 1731922872,
     "path": "coresdk/src/coresdk/input.h",
     "functions": [
       {
@@ -21106,7 +21106,7 @@
     "group": "interface",
     "brief": "SplashKit Interface provides functions to create user interfaces, with elements such as draggable panels, buttons and text boxes.",
     "description": "SplashKit`s interface library provides various functions for creating\npanels, and drawing interface elements such as buttons, text boxes, and more",
-    "parsed_at": 1729338085,
+    "parsed_at": 1731922873,
     "path": "coresdk/src/coresdk/interface.h",
     "functions": [
       {
@@ -24548,7 +24548,7 @@
     "group": "json",
     "brief": "SplashKit Json allows you to create and read JSON objects.",
     "description": "Splashkit's JSON library allows you to easily create or read JSON objects and\nmanipulate them to/from a JSON string or from a file containing a JSON\nstring. Create a new JSON object with a call to `create_json()` and\nread or write data to it by calling methods like\n`json_add_string(json j, string key, string value)` and\n`json_read_string(json j, string key)`.",
-    "parsed_at": 1720129697,
+    "parsed_at": 1731922874,
     "path": "coresdk/src/coresdk/json.h",
     "functions": [
       {
@@ -26300,7 +26300,7 @@
     "group": "input",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129704,
+    "parsed_at": 1731922875,
     "path": "coresdk/src/coresdk/keyboard_input.h",
     "functions": [
       {
@@ -27298,7 +27298,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129709,
+    "parsed_at": 1731922875,
     "path": "coresdk/src/coresdk/line_drawing.h",
     "functions": [
       {
@@ -28837,7 +28837,7 @@
     "group": "geometry",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129712,
+    "parsed_at": 1731922876,
     "path": "coresdk/src/coresdk/line_geometry.h",
     "functions": [
       {
@@ -29711,7 +29711,7 @@
     "group": "logging",
     "brief": "SplashKit Logging facilitates streamlined logging with customizable severity levels and modes.",
     "description": "SplashKit Logging module,  allows users to initialize a custom logger with specified log levels and modes (console, file, or both). \nThe module provides functions to log messages at different severity levels (INFO, DEBUG, WARNING, ERROR, FATAL) with timestamped entries. \nUsers can close the logging process as needed, and the module handles customization for console and file output.",
-    "parsed_at": 1720129713,
+    "parsed_at": 1731922876,
     "path": "coresdk/src/coresdk/logging.h",
     "functions": [
       {
@@ -29960,7 +29960,7 @@
     "group": "physics",
     "brief": "Provides matrix functions to work on 2d coordinates.",
     "description": null,
-    "parsed_at": 1720129716,
+    "parsed_at": 1731922876,
     "path": "coresdk/src/coresdk/matrix_2d.h",
     "functions": [
       {
@@ -30698,7 +30698,7 @@
     "group": "input",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129718,
+    "parsed_at": 1731922876,
     "path": "coresdk/src/coresdk/mouse_input.h",
     "functions": [
       {
@@ -31185,7 +31185,7 @@
     "group": "audio",
     "brief": null,
     "description": null,
-    "parsed_at": 1729338085,
+    "parsed_at": 1731922877,
     "path": "coresdk/src/coresdk/music.h",
     "functions": [
       {
@@ -32215,7 +32215,7 @@
     "group": "networking",
     "brief": "SplashKit's network-related functions allow you to communicate data\nacross networks.",
     "description": null,
-    "parsed_at": 1720129731,
+    "parsed_at": 1731922878,
     "path": "coresdk/src/coresdk/networking.h",
     "functions": [
       {
@@ -35359,7 +35359,7 @@
     "group": "physics",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129732,
+    "parsed_at": 1731922878,
     "path": "coresdk/src/coresdk/physics.h",
     "functions": [
 
@@ -35381,7 +35381,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129736,
+    "parsed_at": 1731922879,
     "path": "coresdk/src/coresdk/point_drawing.h",
     "functions": [
       {
@@ -36701,7 +36701,7 @@
     "group": "geometry",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129739,
+    "parsed_at": 1731922879,
     "path": "coresdk/src/coresdk/point_geometry.h",
     "functions": [
       {
@@ -37725,7 +37725,7 @@
     "group": "geometry",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129741,
+    "parsed_at": 1731922879,
     "path": "coresdk/src/coresdk/quad_geometry.h",
     "functions": [
       {
@@ -38190,7 +38190,7 @@
     "group": "utilities",
     "brief": "SplashKit random provides a simple implementation of random.",
     "description": "The SplashKit`s random library provides two rnd methods, a `rnd()` which generates\na random number between 0 and 1, and `rnd(int ubound)` which\ngenerates a random number between 0 and the value scpeficied in `ubound`.",
-    "parsed_at": 1720129742,
+    "parsed_at": 1731922880,
     "path": "coresdk/src/coresdk/random.h",
     "functions": [
       {
@@ -38324,7 +38324,7 @@
     "group": "raspberry",
     "brief": "Splashkit allows you to read and write to the GPIO pins on the Raspberry Pi.",
     "description": null,
-    "parsed_at": 1729338085,
+    "parsed_at": 1731922880,
     "path": "coresdk/src/coresdk/raspi_gpio.h",
     "functions": [
       {
@@ -38791,7 +38791,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129753,
+    "parsed_at": 1731922881,
     "path": "coresdk/src/coresdk/rectangle_drawing.h",
     "functions": [
       {
@@ -41684,7 +41684,7 @@
     "group": "geometry",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129755,
+    "parsed_at": 1731922881,
     "path": "coresdk/src/coresdk/rectangle_geometry.h",
     "functions": [
       {
@@ -42470,7 +42470,7 @@
     "group": "resources",
     "brief": "SplashKit resource functions allow you to locate resources in a\nproject's `Resources` folder.",
     "description": null,
-    "parsed_at": 1720129757,
+    "parsed_at": 1731922881,
     "path": "coresdk/src/coresdk/resources.h",
     "functions": [
       {
@@ -42788,7 +42788,7 @@
     "group": "audio",
     "brief": null,
     "description": null,
-    "parsed_at": 1729338086,
+    "parsed_at": 1731922882,
     "path": "coresdk/src/coresdk/sound.h",
     "functions": [
       {
@@ -43797,7 +43797,7 @@
     "group": "sprites",
     "brief": "SplashKit Sprites allows you to create images you can easily\nmove and animate.",
     "description": "SplashKit sprites are game elements that can be moved, and animated. Sprites\nare located at a position in the game, have a velocity, and an animation.\nThe sprite can also have arbitary data associated with it for game specific\npurposes.",
-    "parsed_at": 1720129781,
+    "parsed_at": 1731922884,
     "path": "coresdk/src/coresdk/sprites.h",
     "functions": [
       {
@@ -50673,7 +50673,7 @@
     "group": "terminal",
     "brief": "SplashKit Terminal allows you to read and write values to the\nterminal in a consistent manner.",
     "description": null,
-    "parsed_at": 1720129783,
+    "parsed_at": 1731922884,
     "path": "coresdk/src/coresdk/terminal.h",
     "functions": [
       {
@@ -51093,7 +51093,7 @@
     "group": "graphics",
     "brief": "SplashKit Text allows for drawing text in a variety of ways to\ngraphic windows.",
     "description": null,
-    "parsed_at": 1729338086,
+    "parsed_at": 1731922885,
     "path": "coresdk/src/coresdk/text.h",
     "functions": [
       {
@@ -54020,7 +54020,7 @@
     "group": "input",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129793,
+    "parsed_at": 1731922885,
     "path": "coresdk/src/coresdk/text_input.h",
     "functions": [
       {
@@ -54555,7 +54555,7 @@
     "group": "timers",
     "brief": "Timers in SplashKit can be used to track the passing of time.",
     "description": null,
-    "parsed_at": 1720129796,
+    "parsed_at": 1731922886,
     "path": "coresdk/src/coresdk/timers.h",
     "functions": [
       {
@@ -55393,7 +55393,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129803,
+    "parsed_at": 1731922887,
     "path": "coresdk/src/coresdk/triangle_drawing.h",
     "functions": [
       {
@@ -57800,7 +57800,7 @@
     "group": "geometry",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129805,
+    "parsed_at": 1731922887,
     "path": "coresdk/src/coresdk/triangle_geometry.h",
     "functions": [
       {
@@ -58161,7 +58161,7 @@
     "group": "types",
     "brief": "SplashKit Types simplifies data type creation and management for streamlined programming.",
     "description": null,
-    "parsed_at": 1729338087,
+    "parsed_at": 1731922888,
     "path": "coresdk/src/coresdk/types.h",
     "functions": [
 
@@ -59192,7 +59192,7 @@
     "group": "utilities",
     "brief": "SplashKit provides miscellaneous utilities for unclassified functionality.",
     "description": null,
-    "parsed_at": 1720129812,
+    "parsed_at": 1731922888,
     "path": "coresdk/src/coresdk/utils.h",
     "functions": [
       {
@@ -59400,7 +59400,7 @@
     "group": "physics",
     "brief": "Provides vector functions to work on vectors.",
     "description": null,
-    "parsed_at": 1729338088,
+    "parsed_at": 1731922888,
     "path": "coresdk/src/coresdk/vector_2d.h",
     "functions": [
       {
@@ -60833,7 +60833,7 @@
     "group": "networking",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129819,
+    "parsed_at": 1731922889,
     "path": "coresdk/src/coresdk/web_client.h",
     "functions": [
       {
@@ -61428,7 +61428,7 @@
     "group": "networking",
     "brief": null,
     "description": null,
-    "parsed_at": 1720129825,
+    "parsed_at": 1731922889,
     "path": "coresdk/src/coresdk/web_server.h",
     "functions": [
       {
@@ -63147,7 +63147,7 @@
     "group": "windows",
     "brief": "Window Manager in SplashKit can be used create, and manipulate\ngraphics windows",
     "description": null,
-    "parsed_at": 1720129831,
+    "parsed_at": 1731922890,
     "path": "coresdk/src/coresdk/window_manager.h",
     "functions": [
       {


### PR DESCRIPTION
# Description

This pull request updates the generated files based on the changes made in the translator [PR#60](https://github.com/splashkit/splashkit-translator/pull/60).
It also updates the `newText` parameter in the `replace_all` function to use a consistent case (lowercase) and matching name in header and source files.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Generated file updates

## How Has This Been Tested?

TODO: Update this after testing.

## Testing Checklist

- [ ] Tested with sktest
- [ ] Tested with skunit_tests

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
