### PR TITLE
Add bitmap-ray and sprite-ray collision functions

### DIFF
--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -296,6 +296,11 @@ namespace splashkit_lib
 
     bool bitmap_ray_collision(bitmap bmp, int cell, const matrix_2d& translation, const point_2d& origin, const vector_2d& heading)
     {
+        if (INVALID_PTR(bmp, BITMAP_PTR))
+        {
+            return false;
+        }
+        
         point_2d bmp_position = matrix_multiply(translation, point_at(0.0, 0.0));
         point_2d bmp_center = point_offset_by(bmp_position, vector_to(bitmap_center(bmp)));
         circle bmp_bounding_circle = bitmap_bounding_circle(bmp, bmp_center);

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -276,7 +276,7 @@ namespace splashkit_lib
         return bitmap_circle_collision(bmp, cell, translation_matrix(x, y), circ);
     }
 
-    bool bitmap_quad_collision(bitmap bmp, int cell, const matrix_2d &translation, const quad &q)
+    bool bitmap_quad_collision(bitmap bmp, int cell, const matrix_2d &translation, const quad& q)
     {
         if (INVALID_PTR(bmp, BITMAP_PTR))
         {
@@ -294,9 +294,10 @@ namespace splashkit_lib
                                     });
     }
 
-    bool bitmap_ray_collision(bitmap bmp, int cell, const point_2d& pt, const point_2d& ray_origin, const vector_2d& ray_heading)
+    bool bitmap_ray_collision(bitmap bmp, int cell, const matrix_2d& translation, const point_2d& ray_origin, const vector_2d& ray_heading)
     {
-        point_2d bmp_center = point_offset_by(pt, vector_to(bitmap_center(bmp)));
+        point_2d bmp_position = matrix_multiply(translation, point_at(0.0, 0.0));
+        point_2d bmp_center = point_offset_by(bmp_position, vector_to(bitmap_center(bmp)));
         circle bmp_bounding_circle = bitmap_bounding_circle(bmp, bmp_center);
 
         vector_2d unit_ray_heading = unit_vector(ray_heading);
@@ -306,7 +307,27 @@ namespace splashkit_lib
         point_2d ray_end = point_offset_by(ray_origin, vector_multiply(unit_ray_heading, distance_to_center + bmp_bounding_circle.radius));
 
         quad ray_quad = quad_from(ray_origin, ray_end, RAY_QUAD_LINE_THICKNESS);
-        return bitmap_quad_collision(bmp, cell, translation_matrix(pt), ray_quad);
+        return bitmap_quad_collision(bmp, cell, translation, ray_quad);
+    }
+
+    bool bitmap_ray_collision(bitmap bmp, int cell, const point_2d& pt, const point_2d& ray_origin, const vector_2d& ray_heading)
+    {
+        return bitmap_ray_collision(bmp, cell, translation_matrix(pt), ray_origin, ray_heading);
+    }
+
+    bool bitmap_ray_collision(bitmap bmp, int cell, double x, double y, const point_2d& ray_origin, const vector_2d& ray_heading)
+    {
+        return bitmap_ray_collision(bmp, cell, translation_matrix(x, y), ray_origin, ray_heading);
+    }
+
+    bool bitmap_ray_collision(bitmap bmp, double x, double y, const point_2d& ray_origin, const vector_2d& ray_heading)
+    {
+        return bitmap_ray_collision(bmp, 0, translation_matrix(x, y), ray_origin, ray_heading);
+    }
+
+    bool bitmap_ray_collision(bitmap bmp, const point_2d& pt, const point_2d& ray_origin, const vector_2d& ray_heading)
+    {
+        return bitmap_ray_collision(bmp, 0, translation_matrix(pt), ray_origin, ray_heading);
     }
 
     bool sprite_bitmap_collision(sprite s, bitmap bmp, int cell, double x, double y)

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -274,6 +274,30 @@ namespace splashkit_lib
         return bitmap_circle_collision(bmp, cell, translation_matrix(x, y), circ);
     }
 
+    bool bitmap_ray_collision(bitmap bmp, const point_2d& ray_origin, const vector_2d& ray_heading)
+    {
+        // broad phase check
+        point_2d bmp_center = bitmap_center(bmp);
+        circle bmp_bounding_circle = bitmap_bounding_circle(bmp, bmp_center);
+        if (ray_circle_intersect_distance(ray_origin, ray_heading, bmp_bounding_circle) <= -1.0f)
+        {
+            return false;
+        }
+
+        constexpr double THICKNESS = 1.0;
+
+        // narrow phase check
+
+        // get point which will allow segment to fully pass through the bitmap
+        vector_2d unit_ray_heading = unit_vector(ray_heading);
+        point_2d ray_end = point_offset_by(bmp_center, vector_multiply(unit_ray_heading, bmp_bounding_circle.radius));
+
+        // get the quad for the ray
+        quad ray_quad = quad_from(ray_origin, ray_end, THICKNESS);
+
+        // bitmap-quad collision check
+    }
+
     bool sprite_bitmap_collision(sprite s, bitmap bmp, int cell, double x, double y)
     {
         if (!rectangles_intersect(sprite_collision_rectangle(s), bitmap_cell_rectangle(bmp, point_at(x, y))))

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -385,6 +385,11 @@ namespace splashkit_lib
         
         return bitmap_rectangle_collision(sprite_collision_bitmap(s), sprite_current_cell(s), sprite_location_matrix(s), rect);
     }
+
+    bool sprite_ray_collision(sprite s, const point_2d& ray_origin, const vector_2d& ray_heading)
+    {
+        return bitmap_ray_collision(sprite_collision_bitmap(s), sprite_current_cell(s), sprite_location_matrix(s), ray_origin, ray_heading);
+    }
     
     bool sprite_collision(sprite s1, sprite s2)
     {

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -17,6 +17,8 @@
 #include "graphics.h"
 #include "utils.h"
 
+constexpr double RAY_QUAD_LINE_THICKNESS = 1.0;
+
 using std::function;
 
 namespace splashkit_lib
@@ -292,26 +294,19 @@ namespace splashkit_lib
                                     });
     }
 
-    bool bitmap_ray_collision(bitmap bmp, const point_2d& ray_origin, const vector_2d& ray_heading)
+    bool bitmap_ray_collision(bitmap bmp, int cell, const point_2d& pt, const point_2d& ray_origin, const vector_2d& ray_heading)
     {
-        // broad phase check
-        point_2d bmp_center = bitmap_center(bmp);
+        point_2d bmp_center = point_offset_by(pt, vector_to(bitmap_center(bmp)));
         circle bmp_bounding_circle = bitmap_bounding_circle(bmp, bmp_center);
-        if (ray_circle_intersect_distance(ray_origin, ray_heading, bmp_bounding_circle) <= -1.0f)
-        {
-            return false;
-        }
 
-        constexpr double THICKNESS = 1.0;
-
-        // narrow phase check
         vector_2d unit_ray_heading = unit_vector(ray_heading);
 
         // get point which will allow segment to fully pass through the bitmap
-        point_2d ray_end = point_offset_by(bmp_center, vector_multiply(unit_ray_heading, bmp_bounding_circle.radius));
+        double distance_to_center = vector_magnitude(vector_point_to_point(ray_origin, bmp_center));
+        point_2d ray_end = point_offset_by(ray_origin, vector_multiply(unit_ray_heading, distance_to_center + bmp_bounding_circle.radius));
 
-        quad ray_quad = quad_from(ray_origin, ray_end, THICKNESS);
-        return bitmap_quad_collision(bmp, 0, translation_matrix(ray_origin), ray_quad);
+        quad ray_quad = quad_from(ray_origin, ray_end, RAY_QUAD_LINE_THICKNESS);
+        return bitmap_quad_collision(bmp, cell, translation_matrix(pt), ray_quad);
     }
 
     bool sprite_bitmap_collision(sprite s, bitmap bmp, int cell, double x, double y)

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -294,40 +294,40 @@ namespace splashkit_lib
                                     });
     }
 
-    bool bitmap_ray_collision(bitmap bmp, int cell, const matrix_2d& translation, const point_2d& ray_origin, const vector_2d& ray_heading)
+    bool bitmap_ray_collision(bitmap bmp, int cell, const matrix_2d& translation, const point_2d& origin, const vector_2d& heading)
     {
         point_2d bmp_position = matrix_multiply(translation, point_at(0.0, 0.0));
         point_2d bmp_center = point_offset_by(bmp_position, vector_to(bitmap_center(bmp)));
         circle bmp_bounding_circle = bitmap_bounding_circle(bmp, bmp_center);
 
-        vector_2d unit_ray_heading = unit_vector(ray_heading);
+        vector_2d unit_ray_heading = unit_vector(heading);
 
         // get point which will allow segment to fully pass through the bitmap
-        double distance_to_center = vector_magnitude(vector_point_to_point(ray_origin, bmp_center));
-        point_2d ray_end = point_offset_by(ray_origin, vector_multiply(unit_ray_heading, distance_to_center + bmp_bounding_circle.radius));
+        double distance_to_center = vector_magnitude(vector_point_to_point(origin, bmp_center));
+        point_2d ray_end = point_offset_by(origin, vector_multiply(unit_ray_heading, distance_to_center + bmp_bounding_circle.radius));
 
-        quad ray_quad = quad_from(ray_origin, ray_end, RAY_QUAD_LINE_THICKNESS);
+        quad ray_quad = quad_from(origin, ray_end, RAY_QUAD_LINE_THICKNESS);
         return bitmap_quad_collision(bmp, cell, translation, ray_quad);
     }
 
-    bool bitmap_ray_collision(bitmap bmp, int cell, const point_2d& pt, const point_2d& ray_origin, const vector_2d& ray_heading)
+    bool bitmap_ray_collision(bitmap bmp, int cell, const point_2d& pt, const point_2d& origin, const vector_2d& heading)
     {
-        return bitmap_ray_collision(bmp, cell, translation_matrix(pt), ray_origin, ray_heading);
+        return bitmap_ray_collision(bmp, cell, translation_matrix(pt), origin, heading);
     }
 
-    bool bitmap_ray_collision(bitmap bmp, int cell, double x, double y, const point_2d& ray_origin, const vector_2d& ray_heading)
+    bool bitmap_ray_collision(bitmap bmp, int cell, double x, double y, const point_2d& origin, const vector_2d& heading)
     {
-        return bitmap_ray_collision(bmp, cell, translation_matrix(x, y), ray_origin, ray_heading);
+        return bitmap_ray_collision(bmp, cell, translation_matrix(x, y), origin, heading);
     }
 
-    bool bitmap_ray_collision(bitmap bmp, double x, double y, const point_2d& ray_origin, const vector_2d& ray_heading)
+    bool bitmap_ray_collision(bitmap bmp, double x, double y, const point_2d& origin, const vector_2d& heading)
     {
-        return bitmap_ray_collision(bmp, 0, translation_matrix(x, y), ray_origin, ray_heading);
+        return bitmap_ray_collision(bmp, 0, translation_matrix(x, y), origin, heading);
     }
 
-    bool bitmap_ray_collision(bitmap bmp, const point_2d& pt, const point_2d& ray_origin, const vector_2d& ray_heading)
+    bool bitmap_ray_collision(bitmap bmp, const point_2d& pt, const point_2d& origin, const vector_2d& heading)
     {
-        return bitmap_ray_collision(bmp, 0, translation_matrix(pt), ray_origin, ray_heading);
+        return bitmap_ray_collision(bmp, 0, translation_matrix(pt), origin, heading);
     }
 
     bool sprite_bitmap_collision(sprite s, bitmap bmp, int cell, double x, double y)
@@ -386,9 +386,9 @@ namespace splashkit_lib
         return bitmap_rectangle_collision(sprite_collision_bitmap(s), sprite_current_cell(s), sprite_location_matrix(s), rect);
     }
 
-    bool sprite_ray_collision(sprite s, const point_2d& ray_origin, const vector_2d& ray_heading)
+    bool sprite_ray_collision(sprite s, const point_2d& origin, const vector_2d& heading)
     {
-        return bitmap_ray_collision(sprite_collision_bitmap(s), sprite_current_cell(s), sprite_location_matrix(s), ray_origin, ray_heading);
+        return bitmap_ray_collision(sprite_collision_bitmap(s), sprite_current_cell(s), sprite_location_matrix(s), origin, heading);
     }
     
     bool sprite_collision(sprite s1, sprite s2)

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -296,6 +296,25 @@ namespace splashkit_lib
      * @attribute method circle_collision
      */
     bool bitmap_circle_collision(bitmap bmp, const point_2d& pt, const circle& circ);
+
+    /**
+     * Tests if a bitmap cell drawn using a passed in translation, will
+     * intersect with a quad. You can use this to detect collisions between
+     * bitmaps and quads.
+     *
+     * @param  bmp         The bitmap to test
+     * @param  cell        The cell of the bitmap to check
+     * @param  translation The matrix used to transfrom the bitmap when drawing
+     * @param  q           The quad to test
+     * @return             True if a drawn pixel in the cell of the bitmap will
+     *                     intersect with `q` when drawn.
+     *
+     * @attribute suffix    for_cell_with_translation
+     *
+     * @attribute class bitmap
+     * @attribute method quad_collision
+     */
+    bool bitmap_quad_collision(bitmap bmp, int cell, const matrix_2d &translation, const quad &q);
     
     bool bitmap_ray_collision(bitmap bmp, const point_2d& ray_origin, const vector_2d& ray_heading);
 

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -316,7 +316,8 @@ namespace splashkit_lib
      */
     bool bitmap_quad_collision(bitmap bmp, int cell, const matrix_2d &translation, const quad &q);
     
-    bool bitmap_ray_collision(bitmap bmp, const point_2d& ray_origin, const vector_2d& ray_heading);
+    // TODO_M
+    bool bitmap_ray_collision(bitmap bmp, int cell, const point_2d& pt, const point_2d& ray_origin, const vector_2d& ray_heading);
 
     /**
      * Tests if a sprite will collide with a bitmap drawn at the indicated

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -316,19 +316,94 @@ namespace splashkit_lib
      */
     bool bitmap_quad_collision(bitmap bmp, int cell, const matrix_2d &translation, const quad &q);
     
-    // TODO_M
+    /**
+     * Tests if a bitmap cell drawn using a passed in translation, will
+     * intersect with a ray. You can use this to detect collisions between
+     * bitmaps and rays.
+     *
+     * @param  bmp         The bitmap to test
+     * @param  cell        The cell of the bitmap to check
+     * @param  translation The matrix used to transfrom the bitmap when drawing
+     * @param  ray_origin  The origin of the ray
+     * @param  ray_heading The heading of the ray
+     * @return             True if a drawn pixel in the cell of the bitmap will
+     *                     intersect with the ray when drawn.
+     *
+     * @attribute suffix    for_cell_with_translation
+     *
+     * @attribute class bitmap
+     * @attribute method ray_collision
+     */
     bool bitmap_ray_collision(bitmap bmp, int cell, const matrix_2d& translation, const point_2d& ray_origin, const vector_2d& ray_heading);
 
-    // TODO_M
+    /**
+     * Tests if a bitmap cell drawn at `pt` would intersect with a ray.
+     *
+     * @param  bmp        The bitmap to test
+     * @param  cell       The cell of the bitmap to check
+     * @param  pt         The location where the bitmap is drawn
+     * @param  ray_origin The origin of the ray
+     * @param  ray_heading The heading of the ray
+     * @return            True if a drawn pixel in the cell of the bitmap will
+     *                    intersect with the ray when drawn.
+     *
+     * @attribute suffix    for_cell_at_point
+     *
+     * @attribute class bitmap
+     * @attribute method ray_collision
+     */
     bool bitmap_ray_collision(bitmap bmp, int cell, const point_2d& pt, const point_2d& ray_origin, const vector_2d& ray_heading);
 
-    // TODO_M
+    /**
+     * Tests if a bitmap cell drawn at `x`, `y` would intersect with a ray.
+     *
+     * @param  bmp        The bitmap to test
+     * @param  cell       The cell of the bitmap to check
+     * @param  x          The x location where the bitmap is drawn
+     * @param  y          The y location where the bitmap is drawn
+     * @param  ray_origin The origin of the ray
+     * @param  ray_heading The heading of the ray
+     * @return            True if a drawn pixel in the cell of the bitmap will
+     *                    intersect with the ray when drawn.
+     *
+     * @attribute suffix    for_cell
+     *
+     * @attribute class bitmap
+     * @attribute method ray_collision
+     */
     bool bitmap_ray_collision(bitmap bmp, int cell, double x, double y, const point_2d& ray_origin, const vector_2d& ray_heading);
 
-    // TODO_M
+    /**
+     * Tests if a bitmap drawn at `x`, `y` would intersect with a ray.
+     *
+     * @param  bmp        The bitmap to test
+     * @param  x          The x location where the bitmap is drawn
+     * @param  y          The y location where the bitmap is drawn
+     * @param  ray_origin The origin of the ray
+     * @param  ray_heading The heading of the ray
+     * @return            True if a drawn pixel in the bitmap will
+     *                    intersect with the ray when drawn.
+     *
+     * @attribute class bitmap
+     * @attribute method ray_collision
+     */
     bool bitmap_ray_collision(bitmap bmp, double x, double y, const point_2d& ray_origin, const vector_2d& ray_heading);
 
-    // TODO_M
+    /**
+     * Tests if a bitmap drawn at `pt` would intersect with a ray.
+     *
+     * @param  bmp        The bitmap to test
+     * @param  pt         The location where the bitmap is drawn
+     * @param  ray_origin The origin of the ray
+     * @param  ray_heading The heading of the ray
+     * @return            True if a drawn pixel in the cell of the bitmap will
+     *                    intersect with the ray when drawn.
+     *
+     * @attribute suffix    at_point
+     *
+     * @attribute class bitmap
+     * @attribute method ray_collision
+     */
     bool bitmap_ray_collision(bitmap bmp, const point_2d& pt, const point_2d& ray_origin, const vector_2d& ray_heading);
 
     /**
@@ -408,7 +483,17 @@ namespace splashkit_lib
      */
     bool sprite_rectangle_collision(sprite s, const rectangle& rect);
 
-    // TODO_M
+    /**
+     * Tests if a sprite is drawn along a given ray.
+     * 
+     * @param  s           The sprite to test
+     * @param  ray_origin  The origin of the ray
+     * @param  ray_heading The heading of the ray
+     * @return             True if the sprite is drawn along the ray
+     * 
+     * @attribute class sprite
+     * @attribute method ray_collision
+     */
     bool sprite_ray_collision(sprite s, const point_2d& ray_origin, const vector_2d& ray_heading);
 
     /**

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -394,8 +394,8 @@ namespace splashkit_lib
      *
      * @param  bmp        The bitmap to test
      * @param  pt         The location where the bitmap is drawn
-     * @param  ray_origin The origin of the ray
-     * @param  ray_heading The heading of the ray
+     * @param  origin     The origin of the ray
+     * @param  heading    The heading of the ray
      * @return            True if a drawn pixel in the cell of the bitmap will
      *                    intersect with the ray when drawn.
      *

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -408,6 +408,9 @@ namespace splashkit_lib
      */
     bool sprite_rectangle_collision(sprite s, const rectangle& rect);
 
+    // TODO_M
+    bool sprite_ray_collision(sprite s, const point_2d& ray_origin, const vector_2d& ray_heading);
+
     /**
      * Tests if two given sprites `s1` and `s2` are collided
      * @param  s1 the first `sprite` to test

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -297,6 +297,8 @@ namespace splashkit_lib
      */
     bool bitmap_circle_collision(bitmap bmp, const point_2d& pt, const circle& circ);
     
+    bool bitmap_ray_collision(bitmap bmp, const point_2d& ray_origin, const vector_2d& ray_heading);
+
     /**
      * Tests if a sprite will collide with a bitmap drawn at the indicated
      * location.

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -324,8 +324,8 @@ namespace splashkit_lib
      * @param  bmp         The bitmap to test
      * @param  cell        The cell of the bitmap to check
      * @param  translation The matrix used to transfrom the bitmap when drawing
-     * @param  ray_origin  The origin of the ray
-     * @param  ray_heading The heading of the ray
+     * @param  origin      The origin of the ray
+     * @param  heading     The heading of the ray
      * @return             True if a drawn pixel in the cell of the bitmap will
      *                     intersect with the ray when drawn.
      *
@@ -334,7 +334,7 @@ namespace splashkit_lib
      * @attribute class bitmap
      * @attribute method ray_collision
      */
-    bool bitmap_ray_collision(bitmap bmp, int cell, const matrix_2d& translation, const point_2d& ray_origin, const vector_2d& ray_heading);
+    bool bitmap_ray_collision(bitmap bmp, int cell, const matrix_2d& translation, const point_2d& origin, const vector_2d& heading);
 
     /**
      * Tests if a bitmap cell drawn at `pt` would intersect with a ray.
@@ -342,8 +342,8 @@ namespace splashkit_lib
      * @param  bmp        The bitmap to test
      * @param  cell       The cell of the bitmap to check
      * @param  pt         The location where the bitmap is drawn
-     * @param  ray_origin The origin of the ray
-     * @param  ray_heading The heading of the ray
+     * @param  origin     The origin of the ray
+     * @param  heading    The heading of the ray
      * @return            True if a drawn pixel in the cell of the bitmap will
      *                    intersect with the ray when drawn.
      *
@@ -352,7 +352,7 @@ namespace splashkit_lib
      * @attribute class bitmap
      * @attribute method ray_collision
      */
-    bool bitmap_ray_collision(bitmap bmp, int cell, const point_2d& pt, const point_2d& ray_origin, const vector_2d& ray_heading);
+    bool bitmap_ray_collision(bitmap bmp, int cell, const point_2d& pt, const point_2d& origin, const vector_2d& heading);
 
     /**
      * Tests if a bitmap cell drawn at `x`, `y` would intersect with a ray.
@@ -361,8 +361,8 @@ namespace splashkit_lib
      * @param  cell       The cell of the bitmap to check
      * @param  x          The x location where the bitmap is drawn
      * @param  y          The y location where the bitmap is drawn
-     * @param  ray_origin The origin of the ray
-     * @param  ray_heading The heading of the ray
+     * @param  origin     The origin of the ray
+     * @param  heading    The heading of the ray
      * @return            True if a drawn pixel in the cell of the bitmap will
      *                    intersect with the ray when drawn.
      *
@@ -371,7 +371,7 @@ namespace splashkit_lib
      * @attribute class bitmap
      * @attribute method ray_collision
      */
-    bool bitmap_ray_collision(bitmap bmp, int cell, double x, double y, const point_2d& ray_origin, const vector_2d& ray_heading);
+    bool bitmap_ray_collision(bitmap bmp, int cell, double x, double y, const point_2d& origin, const vector_2d& heading);
 
     /**
      * Tests if a bitmap drawn at `x`, `y` would intersect with a ray.
@@ -379,15 +379,15 @@ namespace splashkit_lib
      * @param  bmp        The bitmap to test
      * @param  x          The x location where the bitmap is drawn
      * @param  y          The y location where the bitmap is drawn
-     * @param  ray_origin The origin of the ray
-     * @param  ray_heading The heading of the ray
+     * @param  origin     The origin of the ray
+     * @param  heading    The heading of the ray 
      * @return            True if a drawn pixel in the bitmap will
      *                    intersect with the ray when drawn.
      *
      * @attribute class bitmap
      * @attribute method ray_collision
      */
-    bool bitmap_ray_collision(bitmap bmp, double x, double y, const point_2d& ray_origin, const vector_2d& ray_heading);
+    bool bitmap_ray_collision(bitmap bmp, double x, double y, const point_2d& origin, const vector_2d& heading);
 
     /**
      * Tests if a bitmap drawn at `pt` would intersect with a ray.
@@ -404,7 +404,7 @@ namespace splashkit_lib
      * @attribute class bitmap
      * @attribute method ray_collision
      */
-    bool bitmap_ray_collision(bitmap bmp, const point_2d& pt, const point_2d& ray_origin, const vector_2d& ray_heading);
+    bool bitmap_ray_collision(bitmap bmp, const point_2d& pt, const point_2d& origin, const vector_2d& heading);
 
     /**
      * Tests if a sprite will collide with a bitmap drawn at the indicated
@@ -487,14 +487,14 @@ namespace splashkit_lib
      * Tests if a sprite is drawn along a given ray.
      * 
      * @param  s           The sprite to test
-     * @param  ray_origin  The origin of the ray
-     * @param  ray_heading The heading of the ray
+     * @param  origin      The origin of the ray
+     * @param  heading     The heading of the ray
      * @return             True if the sprite is drawn along the ray
      * 
      * @attribute class sprite
      * @attribute method ray_collision
      */
-    bool sprite_ray_collision(sprite s, const point_2d& ray_origin, const vector_2d& ray_heading);
+    bool sprite_ray_collision(sprite s, const point_2d& origin, const vector_2d& heading);
 
     /**
      * Tests if two given sprites `s1` and `s2` are collided

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -317,7 +317,19 @@ namespace splashkit_lib
     bool bitmap_quad_collision(bitmap bmp, int cell, const matrix_2d &translation, const quad &q);
     
     // TODO_M
+    bool bitmap_ray_collision(bitmap bmp, int cell, const matrix_2d& translation, const point_2d& ray_origin, const vector_2d& ray_heading);
+
+    // TODO_M
     bool bitmap_ray_collision(bitmap bmp, int cell, const point_2d& pt, const point_2d& ray_origin, const vector_2d& ray_heading);
+
+    // TODO_M
+    bool bitmap_ray_collision(bitmap bmp, int cell, double x, double y, const point_2d& ray_origin, const vector_2d& ray_heading);
+
+    // TODO_M
+    bool bitmap_ray_collision(bitmap bmp, double x, double y, const point_2d& ray_origin, const vector_2d& ray_heading);
+
+    // TODO_M
+    bool bitmap_ray_collision(bitmap bmp, const point_2d& pt, const point_2d& ray_origin, const vector_2d& ray_heading);
 
     /**
      * Tests if a sprite will collide with a bitmap drawn at the indicated

--- a/coresdk/src/coresdk/images.cpp
+++ b/coresdk/src/coresdk/images.cpp
@@ -388,7 +388,7 @@ namespace splashkit_lib
             return circle_at(0, 0, 0);
         }
 
-        return circle_at(pt, MAX(bmp->cell_w, bmp->cell_h) / 2.0f * scale);
+        return circle_at(pt, sqrt(pow(bmp->cell_w / 2.0, 2.0) + pow(bmp->cell_h / 2.0, 2.0)) * scale);
     }
 
     circle bitmap_cell_circle(bitmap bmp, const point_2d pt)
@@ -408,7 +408,7 @@ namespace splashkit_lib
             return circle_at(0,0,0);
         }
 
-        return circle_at(pt, MAX(bmp->image.surface.width, bmp->image.surface.height));
+        return circle_at(pt, sqrt(pow(bmp->image.surface.width / 2.0, 2.0) + pow(bmp->image.surface.height / 2.0, 2.0)));
     }
 
     int bitmap_cell_columns(bitmap bmp)

--- a/coresdk/src/coresdk/quad_geometry.cpp
+++ b/coresdk/src/coresdk/quad_geometry.cpp
@@ -59,17 +59,17 @@ namespace splashkit_lib
         return result;
     }
 
-    quad quad_from(const point_2d& segment_origin, const point_2d& segment_end, double width)
+    quad quad_from(const point_2d& line_origin, const point_2d& line_end, double width)
     {
-        vector_2d heading = vector_point_to_point(segment_origin, segment_end);
+        vector_2d heading = vector_point_to_point(line_origin, line_end);
         vector_2d normal = vector_normal(heading);
         vector_2d offset = vector_multiply(normal, width / 2.0);
 
         quad result;
-        result.points[0] = point_offset_by(segment_origin, offset);
-        result.points[1] = point_offset_by(segment_end, offset);
-        result.points[2] = point_offset_by(segment_origin, vector_invert(offset));
-        result.points[3] = point_offset_by(segment_end, vector_invert(offset));
+        result.points[0] = point_offset_by(line_origin, offset);
+        result.points[1] = point_offset_by(line_end, offset);
+        result.points[2] = point_offset_by(line_origin, vector_invert(offset));
+        result.points[3] = point_offset_by(line_end, vector_invert(offset));
 
         return result;
     }

--- a/coresdk/src/coresdk/quad_geometry.cpp
+++ b/coresdk/src/coresdk/quad_geometry.cpp
@@ -59,6 +59,21 @@ namespace splashkit_lib
         return result;
     }
 
+    quad quad_from(const point_2d& segment_origin, const point_2d& segment_end, double width)
+    {
+        vector_2d heading = vector_point_to_point(segment_origin, segment_end);
+        vector_2d normal = vector_normal(heading);
+        vector_2d offset = vector_multiply(normal, width / 2.0);
+
+        quad result;
+        result.points[0] = point_offset_by(segment_origin, offset);
+        result.points[1] = point_offset_by(segment_end, offset);
+        result.points[2] = point_offset_by(segment_origin, vector_invert(offset));
+        result.points[3] = point_offset_by(segment_end, vector_invert(offset));
+
+        return result;
+    }
+
     void set_quad_point(quad &q, int idx, const point_2d &value)
     {
         if (idx < 0 || idx > 3)

--- a/coresdk/src/coresdk/quad_geometry.h
+++ b/coresdk/src/coresdk/quad_geometry.h
@@ -74,16 +74,18 @@ namespace splashkit_lib
                    const point_2d &p4);
 
     /**
-     * Returns a quad from the passed in segment and width.
+     * Returns a quad from the passed in line and width.
+     * The quad will be a rectangle with the line as the diagonal,
+     * and the width as the width of the rectangle.
      * 
-     * @param segment_origin The origin of the segment
-     * @param segment_end    The end of the segment
+     * @param line_origin    The origin of the line
+     * @param line_end       The end of the line
      * @param width          The width of the quad
-     * @return               A quad that represents the segment with the given width
+     * @return               A quad that represents the line with the given width
      * 
-     * @attribute suffix  from_segment
+     * @attribute suffix  from_line
      */
-    quad quad_from(const point_2d& segment_origin, const point_2d& segment_end, double width);
+    quad quad_from(const point_2d& line_origin, const point_2d& line_end, double width);
 
     /**
      * Change a point in a quad.

--- a/coresdk/src/coresdk/quad_geometry.h
+++ b/coresdk/src/coresdk/quad_geometry.h
@@ -73,7 +73,16 @@ namespace splashkit_lib
                    const point_2d &p3,
                    const point_2d &p4);
 
-    // TODO_M
+    /**
+     * Returns a quad from the passed in segment and width.
+     * 
+     * @param segment_origin The origin of the segment
+     * @param segment_end    The end of the segment
+     * @param width          The width of the quad
+     * @return               A quad that represents the segment with the given width
+     * 
+     * @attribute suffix  from_segment
+     */
     quad quad_from(const point_2d& segment_origin, const point_2d& segment_end, double width);
 
     /**

--- a/coresdk/src/coresdk/quad_geometry.h
+++ b/coresdk/src/coresdk/quad_geometry.h
@@ -73,6 +73,9 @@ namespace splashkit_lib
                    const point_2d &p3,
                    const point_2d &p4);
 
+    // TODO_M
+    quad quad_from(const point_2d& segment_origin, const point_2d& segment_end, double width);
+
     /**
      * Change a point in a quad.
      *

--- a/coresdk/src/test/test_geometry.cpp
+++ b/coresdk/src/test/test_geometry.cpp
@@ -267,10 +267,6 @@ void test_bitmap_ray_collision()
             ray_origin.x -= 1.0;
         if (key_down(RIGHT_KEY))
             ray_origin.x += 1.0;
-
-        ray_heading = vector_point_to_point(ray_origin, mouse_position());
-        vector_2d normal_heading = unit_vector(ray_heading);
-        draw_line(COLOR_BLACK, ray_origin, point_offset_by(ray_origin, vector_multiply(normal_heading, 800.0)));
         
         bool collision_1 = bitmap_ray_collision(bmp_1, 0, bmp_1_position, ray_origin, ray_heading);
         bool collision_2 = bitmap_ray_collision(bmp_2, 0, bmp_2_position, ray_origin, ray_heading);
@@ -293,6 +289,10 @@ void test_bitmap_ray_collision()
         {
             fill_circle(COLOR_RED, circle_at(bmp_3_center, 30.0));
         }
+
+        ray_heading = vector_point_to_point(ray_origin, mouse_position());
+        vector_2d normal_heading = unit_vector(ray_heading);
+        draw_line(COLOR_BLACK, ray_origin, point_offset_by(ray_origin, vector_multiply(normal_heading, 800.0)));
 
         circle mouse_circle = circle_at(mouse_position(), 3.0);
         draw_circle(COLOR_GREEN, mouse_circle);

--- a/coresdk/src/test/test_geometry.cpp
+++ b/coresdk/src/test/test_geometry.cpp
@@ -239,10 +239,77 @@ void test_triangle()
     close_window(w1);
 }
 
+void test_bitmap_ray_collision()
+{
+    window w1 = open_window("Bitmap Ray Collision", 800, 600);
+    bitmap bmp_1 = load_bitmap("on_med", "on_med.png");
+    point_2d bmp_1_position = point_at(300.0, 300.0);
+    point_2d bmp_1_center = point_offset_by(bmp_1_position, vector_to(bitmap_center(bmp_1)));
+    bitmap bmp_2 = load_bitmap("rocket_sprt", "rocket_sprt.png");
+    point_2d bmp_2_position = point_at(500.0, 300.0);
+    point_2d bmp_2_center = point_offset_by(bmp_2_position, vector_to(bitmap_center(bmp_2)));
+    bitmap bmp_3 = load_bitmap("up_pole", "up_pole.png");
+    point_2d bmp_3_position = point_at(700.0, 300.0);
+    point_2d bmp_3_center = point_offset_by(bmp_3_position, vector_to(bitmap_center(bmp_3)));
+    point_2d ray_origin = point_at(100, 100);
+    vector_2d ray_heading = vector_to(200, 200);
+    
+    while ( !window_close_requested(w1) ) {
+        process_events();
+        
+        clear_screen(COLOR_WHITE);
+
+        if (key_down(UP_KEY))
+            ray_origin.y -= 1.0;
+        if (key_down(DOWN_KEY))
+            ray_origin.y += 1.0;
+        if (key_down(LEFT_KEY))
+            ray_origin.x -= 1.0;
+        if (key_down(RIGHT_KEY))
+            ray_origin.x += 1.0;
+
+        ray_heading = vector_point_to_point(ray_origin, mouse_position());
+        vector_2d normal_heading = unit_vector(ray_heading);
+        draw_line(COLOR_BLACK, ray_origin, point_offset_by(ray_origin, vector_multiply(normal_heading, 800.0)));
+        
+        bool collision_1 = bitmap_ray_collision(bmp_1, 0, bmp_1_position, ray_origin, ray_heading);
+        bool collision_2 = bitmap_ray_collision(bmp_2, 0, bmp_2_position, ray_origin, ray_heading);
+        bool collision_3 = bitmap_ray_collision(bmp_3, 0, bmp_3_position, ray_origin, ray_heading);
+
+        draw_bitmap(bmp_1, bmp_1_position.x, bmp_1_position.y);
+        if (collision_1)
+        {
+            fill_circle(COLOR_RED, circle_at(bmp_1_center, 30.0));
+        }
+
+        draw_bitmap(bmp_2, bmp_2_position.x, bmp_2_position.y);
+        if (collision_2)
+        {
+            fill_circle(COLOR_RED, circle_at(bmp_2_center, 8.0));
+        }
+
+        draw_bitmap(bmp_3, bmp_3_position.x, bmp_3_position.y);
+        if (collision_3)
+        {
+            fill_circle(COLOR_RED, circle_at(bmp_3_center, 30.0));
+        }
+
+        circle mouse_circle = circle_at(mouse_position(), 3.0);
+        draw_circle(COLOR_GREEN, mouse_circle);
+
+        circle ray_origin_circle = circle_at(ray_origin, 3.0);
+        draw_circle(COLOR_BLUE, ray_origin_circle);
+        
+        refresh_screen();
+    }
+    close_window(w1);
+}
+
 void run_geometry_test()
 {
-    test_rectangle();
-    test_points();
-    test_lines();
-    test_triangle();
+    // test_rectangle();
+    // test_points();
+    // test_lines();
+    // test_triangle();
+    test_bitmap_ray_collision();
 }

--- a/coresdk/src/test/test_geometry.cpp
+++ b/coresdk/src/test/test_geometry.cpp
@@ -307,9 +307,9 @@ void test_bitmap_ray_collision()
 
 void run_geometry_test()
 {
-    // test_rectangle();
-    // test_points();
-    // test_lines();
-    // test_triangle();
+    test_rectangle();
+    test_points();
+    test_lines();
+    test_triangle();
     test_bitmap_ray_collision();
 }

--- a/coresdk/src/test/test_sprites.cpp
+++ b/coresdk/src/test/test_sprites.cpp
@@ -16,7 +16,7 @@
 
 using namespace splashkit_lib;
 
-void run_sprite_test()
+void sprite_test()
 {
     sprite sprt, s2;
     triangle tri, init_tri;
@@ -148,11 +148,13 @@ void test_sprite_ray_collision()
 {
     window w1 = open_window("Sprite Ray Collision", 800, 600);
     sprite s1 = create_sprite("on_med.png");
-    sprite_set_position(s1, point_at(300.0, 300.0));
+    sprite_set_position(s1, point_at(200.0, 200.0));
+    sprite_set_rotation(s1, 45.0f);
     sprite s2 = create_sprite("rocket_sprt.png");
-    sprite_set_position(s2, point_at(500.0, 300.0));
+    sprite_set_position(s2, point_at(500.0, 100.0));
     sprite s3 = create_sprite("up_pole.png");
-    sprite_set_position(s3, point_at(700.0, 300.0));
+    sprite_set_position(s3, point_at(600.0, 300.0));
+    sprite_set_rotation(s3, 10.0f);
     point_2d ray_origin = point_at(100, 100);
     vector_2d ray_heading = vector_to(200, 200);
     
@@ -177,7 +179,7 @@ void test_sprite_ray_collision()
         draw_sprite(s1);
         if (collision_1)
         {
-            fill_circle(COLOR_RED, circle_at(sprite_collision_circle(s1).center, 8.0));
+            fill_circle(COLOR_RED, circle_at(sprite_collision_circle(s1).center, 30.0));
         }
 
         draw_sprite(s2);
@@ -205,4 +207,10 @@ void test_sprite_ray_collision()
         refresh_screen();
     }
     close_window(w1);
+}
+
+void run_sprite_test()
+{
+    sprite_test();
+    test_sprite_ray_collision();
 }

--- a/coresdk/src/test/test_sprites.cpp
+++ b/coresdk/src/test/test_sprites.cpp
@@ -143,3 +143,66 @@ void run_sprite_test()
     
     close_all_windows();
 }
+
+void test_sprite_ray_collision()
+{
+    window w1 = open_window("Sprite Ray Collision", 800, 600);
+    sprite s1 = create_sprite("on_med.png");
+    sprite_set_position(s1, point_at(300.0, 300.0));
+    sprite s2 = create_sprite("rocket_sprt.png");
+    sprite_set_position(s2, point_at(500.0, 300.0));
+    sprite s3 = create_sprite("up_pole.png");
+    sprite_set_position(s3, point_at(700.0, 300.0));
+    point_2d ray_origin = point_at(100, 100);
+    vector_2d ray_heading = vector_to(200, 200);
+    
+    while ( !window_close_requested(w1) ) {
+        process_events();
+        
+        clear_screen(COLOR_WHITE);
+
+        if (key_down(UP_KEY))
+            ray_origin.y -= 1.0;
+        if (key_down(DOWN_KEY))
+            ray_origin.y += 1.0;
+        if (key_down(LEFT_KEY))
+            ray_origin.x -= 1.0;
+        if (key_down(RIGHT_KEY))
+            ray_origin.x += 1.0;
+        
+        bool collision_1 = sprite_ray_collision(s1, ray_origin, ray_heading);
+        bool collision_2 = sprite_ray_collision(s2, ray_origin, ray_heading);
+        bool collision_3 = sprite_ray_collision(s3, ray_origin, ray_heading);
+
+        draw_sprite(s1);
+        if (collision_1)
+        {
+            fill_circle(COLOR_RED, circle_at(sprite_collision_circle(s1).center, 8.0));
+        }
+
+        draw_sprite(s2);
+        if (collision_2)
+        {
+            fill_circle(COLOR_RED, circle_at(sprite_collision_circle(s2).center, 8.0));
+        }
+
+        draw_sprite(s3);
+        if (collision_3)
+        {
+            fill_circle(COLOR_RED, circle_at(sprite_collision_circle(s3).center, 30.0));
+        }
+
+        ray_heading = vector_point_to_point(ray_origin, mouse_position());
+        vector_2d normal_heading = unit_vector(ray_heading);
+        draw_line(COLOR_BLACK, ray_origin, point_offset_by(ray_origin, vector_multiply(normal_heading, 800.0)));
+
+        circle mouse_circle = circle_at(mouse_position(), 3.0);
+        draw_circle(COLOR_GREEN, mouse_circle);
+
+        circle ray_origin_circle = circle_at(ray_origin, 3.0);
+        draw_circle(COLOR_BLUE, ray_origin_circle);
+        
+        refresh_screen();
+    }
+    close_window(w1);
+}


### PR DESCRIPTION
# Description

There has been growing interest in using SplashKit to perform ray-tracing in both 2D and 3D environments. However, there is a lack of ray-based functions, particularly with detecting pixel-based collisions. I have added bitmap-ray and sprite-ray functions which will allow for more advanced ray-tracing, going beyond the primitive shapes.

### quad_from
This function constructs a quad around a passed-in segment. The width of the quad along the segment is also passed in as an argument.

### bitmap_quad_collision
I made use of a function which I previously developed and submitted in a previous PR: https://github.com/splashkit/splashkit-core/pull/197. Unlike in the previous PR, I did not include the 4 overloads in this PR.

### bitmap_bounding_circle bug fix
`bitmap_ray_collision` calls `bitmap_bounding_circle` which contains a bug. The bug was detected and fixed in a previous PR: https://github.com/splashkit/splashkit-core/pull/195. I copied the bug fix into this PR as it was necessary for accurate functioning of `bitmap_ray_collision`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I added two new tests to `sktest`: one in each of `test_geometry.cpp` and `test_sprites.cpp`. These real-time graphical tests allow the user to control a ray by using the arrow keys and mouse. There are bitmaps and sprites in their respective tests which indicate whether a collision has occurred.

## Testing Checklist

- [x] Tested with sktest

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings