### PR TITLE
Add ray intersection tests for primitive shapes

### DIFF
--- a/coresdk/src/coresdk/circle_geometry.cpp
+++ b/coresdk/src/coresdk/circle_geometry.cpp
@@ -98,6 +98,33 @@ namespace splashkit_lib
             return (v - sqrt(d));
     }
 
+    bool circle_ray_intersection(const point_2d &origin, const vector_2d &heading, const circle &circ)
+    {
+        point_2d hit_point;
+        double hit_distance;
+        return circle_ray_intersection(origin, heading, circ, hit_point, hit_distance);
+    }
+
+    bool circle_ray_intersection(const point_2d &origin, const vector_2d &heading, const circle &circ, point_2d &hit_point, double &hit_distance)
+    {
+        if (point_in_circle(origin, circ))
+        {
+            hit_point = origin;
+            hit_distance = 0.0;
+            return true;
+        }
+        
+        float distance = ray_circle_intersect_distance(origin, heading, circ);
+        if (distance < 0.0f)
+        {
+            return false;
+        }
+
+        hit_distance = static_cast<double>(distance);
+        hit_point = point_offset_by(origin, vector_multiply(heading, hit_distance));
+        return true;
+    }
+
     bool circles_intersect(circle c1, circle c2)
     {
         return point_point_distance(c1.center, c2.center) < c1.radius + c2.radius;

--- a/coresdk/src/coresdk/circle_geometry.h
+++ b/coresdk/src/coresdk/circle_geometry.h
@@ -151,6 +151,33 @@ namespace splashkit_lib
     float ray_circle_intersect_distance(const point_2d &ray_origin, const vector_2d &ray_heading, const circle &c);
 
     /**
+     * Detects if a ray intersects a circle.
+     * 
+     * @param origin        The starting point of the ray
+     * @param heading       The direction of the ray as a vector
+     * @param circ          The circle to check for intersection
+     * @returns             True if the ray intersects the circle, false otherwise
+     */
+    bool circle_ray_intersection(const point_2d &origin, const vector_2d &heading, const circle &circ);
+
+    /**
+     * Detects if a ray intersects a circle. If an intersection is found, the
+     * `hit_point` and `hit_distance` are set to the point of intersection and the
+     * distance from the ray's origin to the intersection point. If the ray's `origin`
+     * is contained within the circle, `hit_point` is set to the `origin` and `hit_distance`
+     * is set to 0. If no intersection is found, `hit_point` and `hit_distance` are not modified.
+     * 
+     * @param origin        The starting point of the ray
+     * @param heading       The direction of the ray as a vector
+     * @param circ          The circle to check for intersection
+     * @param hit_point     The point to set to where the ray intersects the circle
+     * @param hit_distance  The double to set to the distance from the ray's origin to
+     *                      the intersection point
+     * @returns             True if the ray intersects the circle, false otherwise
+     */
+    bool circle_ray_intersection(const point_2d &origin, const vector_2d &heading, const circle &circ, point_2d &hit_point, double &hit_distance);
+
+    /**
      *  Returns the circle radius.
      *
      * @param  c The circle

--- a/coresdk/src/coresdk/quad_geometry.cpp
+++ b/coresdk/src/coresdk/quad_geometry.cpp
@@ -77,6 +77,40 @@ namespace splashkit_lib
         return result;
     }
 
+    bool quad_ray_intersection(const point_2d &origin, const vector_2d &heading, const quad &q)
+    {
+        point_2d hit_point;
+        double hit_distance;
+        return quad_ray_intersection(origin, heading, q, hit_point, hit_distance);
+    }
+
+    bool quad_ray_intersection(const point_2d &origin, const vector_2d &heading, const quad &q, point_2d &hit_point, double &hit_distance)
+    {
+        vector<triangle> tris = triangles_from(q);
+
+        bool result = false;
+        double closest_distance = __DBL_MAX__;
+
+        for (triangle t : tris)
+        {
+            point_2d p;
+            double d;
+            if (triangle_ray_intersection(origin, heading, t, p, d))
+            {
+                double distance_to_intersection = vector_magnitude(vector_point_to_point(origin, p));
+                if (distance_to_intersection < closest_distance)
+                {
+                    closest_distance = distance_to_intersection;
+                    hit_point = p;
+                    hit_distance = d;
+                    result = true;
+                }
+            }
+        }
+
+        return result;
+    }
+
     bool quads_intersect(const quad &q1, const quad &q2)
     {
         vector<triangle> q1_triangles = triangles_from(q1);

--- a/coresdk/src/coresdk/quad_geometry.cpp
+++ b/coresdk/src/coresdk/quad_geometry.cpp
@@ -91,11 +91,11 @@ namespace splashkit_lib
         bool result = false;
         double closest_distance = __DBL_MAX__;
 
-        for (triangle t : tris)
+        for (size_t i = 0; i < tris.size(); i++)
         {
             point_2d p;
             double d;
-            if (triangle_ray_intersection(origin, heading, t, p, d))
+            if (triangle_ray_intersection(origin, heading, tris[i], p, d))
             {
                 double distance_to_intersection = vector_magnitude(vector_point_to_point(origin, p));
                 if (distance_to_intersection < closest_distance)

--- a/coresdk/src/coresdk/quad_geometry.h
+++ b/coresdk/src/coresdk/quad_geometry.h
@@ -84,6 +84,33 @@ namespace splashkit_lib
     void set_quad_point(quad &q, int idx, const point_2d &value);
 
     /**
+     * Detects if a ray intersects a quad.
+     * 
+     * @param origin        The starting point of the ray
+     * @param heading       The direction of the ray as a vector
+     * @param quad          The quad to check for intersection
+     * @returns             True if the ray intersects the quad, false otherwise
+     */
+    bool quad_ray_intersection(const point_2d &origin, const vector_2d &heading, const quad &q);
+
+    /**
+     * Detects if a ray intersects a quad. If an intersection is found, the
+     * `hit_point` and `hit_distance` are set to the point of intersection and the
+     * distance from the ray's origin to the intersection point. If the ray's `origin`
+     * is contained within the quad, `hit_point` is set to the `origin` and `hit_distance`
+     * is set to 0. If no intersection is found, `hit_point` and `hit_distance` are not modified.
+     * 
+     * @param origin        The starting point of the ray
+     * @param heading       The direction of the ray as a vector
+     * @param quad          The quad to check for intersection
+     * @param hit_point     The point to set to where the ray intersects the quad
+     * @param hit_distance  The double to set to the distance from the ray's origin to
+     *                      the intersection point
+     * @returns             True if the ray intersects the quad, false otherwise
+     */
+    bool quad_ray_intersection(const point_2d &origin, const vector_2d &heading, const quad &q, point_2d &hit_point, double &hit_distance);
+
+    /**
      * Returns true if two quads intersect.
      *
      * @param  q1 The first quad

--- a/coresdk/src/coresdk/rectangle_geometry.cpp
+++ b/coresdk/src/coresdk/rectangle_geometry.cpp
@@ -228,15 +228,17 @@ namespace splashkit_lib
     {
         point_2d hit_point;
         double hit_distance;
-
         return rectangle_ray_intersection(origin, heading, rect, hit_point, hit_distance);
     }
 
     bool rectangle_ray_intersection(const point_2d &origin, const vector_2d &direction, const rectangle &rect, point_2d &hit_point, double &hit_distance)
     {
-        // // Define the range of intersection distances along the ray
-        // double min_intersection_distance = -screen_diagonal();
-        // double max_intersection_distance = screen_diagonal();
+        if (point_in_rectangle(origin, rect))
+        {
+            hit_point = origin;
+            hit_distance = 0.0;
+            return true;
+        }
 
         // Compute the inverse of the ray direction (for faster calculations)
         vector_2d inv_dir = vector_to(1.0 / direction.x, 1.0 / direction.y);
@@ -253,7 +255,7 @@ namespace splashkit_lib
         double max_intersection_distance = std::min(std::max(entry_distance_x, exit_distance_x), std::max(entry_distance_y, exit_distance_y));
 
         // If the ray misses the rectangle or the intersection is behind the ray's origin
-        if (min_intersection_distance > max_intersection_distance || max_intersection_distance < 0)
+        if (min_intersection_distance > max_intersection_distance || max_intersection_distance < 0.0)
         {
             return false;
         }

--- a/coresdk/src/coresdk/rectangle_geometry.cpp
+++ b/coresdk/src/coresdk/rectangle_geometry.cpp
@@ -223,4 +223,46 @@ namespace splashkit_lib
 
         return result;
     }
+
+    bool rectangle_ray_intersection(const point_2d &origin, const vector_2d &heading, const rectangle &rect)
+    {
+        point_2d hit_point;
+        double hit_distance;
+
+        return rectangle_ray_intersection(origin, heading, rect, hit_point, hit_distance);
+    }
+
+    bool rectangle_ray_intersection(const point_2d &origin, const vector_2d &direction, const rectangle &rect, point_2d &hit_point, double &hit_distance)
+    {
+        // // Define the range of intersection distances along the ray
+        // double min_intersection_distance = -screen_diagonal();
+        // double max_intersection_distance = screen_diagonal();
+
+        // Compute the inverse of the ray direction (for faster calculations)
+        vector_2d inv_dir = vector_to(1.0 / direction.x, 1.0 / direction.y);
+
+        // Calculate entry and exit distances for the rectangle's x and y boundaries
+        double entry_distance_x = (rect.x - origin.x) * inv_dir.x;
+        double exit_distance_x = (rect.x + rect.width - origin.x) * inv_dir.x;
+
+        double entry_distance_y = (rect.y - origin.y) * inv_dir.y;
+        double exit_distance_y = (rect.y + rect.height - origin.y) * inv_dir.y;
+
+        // Determine the nearest entry point and the farthest exit point
+        double min_intersection_distance = std::max(std::min(entry_distance_x, exit_distance_x), std::min(entry_distance_y, exit_distance_y));
+        double max_intersection_distance = std::min(std::max(entry_distance_x, exit_distance_x), std::max(entry_distance_y, exit_distance_y));
+
+        // If the ray misses the rectangle or the intersection is behind the ray's origin
+        if (min_intersection_distance > max_intersection_distance || max_intersection_distance < 0)
+        {
+            return false;
+        }
+
+        // Compute the point of intersection
+        hit_distance = min_intersection_distance;
+        vector_2d hit_vector = vector_multiply(direction, min_intersection_distance);
+        hit_point = point_at(origin.x + hit_vector.x, origin.y + hit_vector.y);
+
+        return true;
+    }
 }

--- a/coresdk/src/coresdk/rectangle_geometry.h
+++ b/coresdk/src/coresdk/rectangle_geometry.h
@@ -178,5 +178,18 @@ namespace splashkit_lib
      */
     rectangle inset_rectangle(const rectangle &rect, float inset_amount);
 
+
+    bool rectangle_ray_intersection(const point_2d &origin, const vector_2d &heading, const rectangle &rect);
+
+
+    // Function to detect if a ray intersects a rectangle
+    // Parameters:
+    // - origin: The starting point of the ray
+    // - direction: The direction of the ray as a vector
+    // - rect: The rectangle to check for intersection
+    // - hit_point: The point where the ray intersects the rectangle (output)
+    // - hit_distance: The distance from the ray's origin to the intersection point (output)
+    bool rectangle_ray_intersection(const point_2d &origin, const vector_2d &heading, const rectangle &rect, point_2d &hit_point, double &hit_distance);
+
 }
 #endif /* rectangle_geometry_H */

--- a/coresdk/src/coresdk/rectangle_geometry.h
+++ b/coresdk/src/coresdk/rectangle_geometry.h
@@ -190,9 +190,10 @@ namespace splashkit_lib
 
     /**
      * Detects if a ray intersects a rectangle. If an intersection is found, the
-     * hit_point and hit_distance are set to the point of intersection and the
-     * distance from the ray's origin to the intersection point. If no intersection
-     * is found, hit_point and hit_distance are not modified.
+     * `hit_point` and `hit_distance` are set to the point of intersection and the
+     * distance from the ray's origin to the intersection point. If the ray's `origin`
+     * is contained within the rectangle, `hit_point` is set to the `origin` and `hit_distance`
+     * is set to 0. If no intersection is found, `hit_point` and `hit_distance` are not modified.
      * 
      * @param origin        The starting point of the ray
      * @param heading       The direction of the ray as a vector

--- a/coresdk/src/coresdk/rectangle_geometry.h
+++ b/coresdk/src/coresdk/rectangle_geometry.h
@@ -178,17 +178,30 @@ namespace splashkit_lib
      */
     rectangle inset_rectangle(const rectangle &rect, float inset_amount);
 
-
+    /**
+     * Detects if a ray intersects a rectangle.
+     * 
+     * @param origin        The starting point of the ray
+     * @param heading       The direction of the ray as a vector
+     * @param rect          The rectangle to check for intersection
+     * @returns             True if the ray intersects the rectangle, false otherwise
+     */
     bool rectangle_ray_intersection(const point_2d &origin, const vector_2d &heading, const rectangle &rect);
 
-
-    // Function to detect if a ray intersects a rectangle
-    // Parameters:
-    // - origin: The starting point of the ray
-    // - direction: The direction of the ray as a vector
-    // - rect: The rectangle to check for intersection
-    // - hit_point: The point where the ray intersects the rectangle (output)
-    // - hit_distance: The distance from the ray's origin to the intersection point (output)
+    /**
+     * Detects if a ray intersects a rectangle. If an intersection is found, the
+     * hit_point and hit_distance are set to the point of intersection and the
+     * distance from the ray's origin to the intersection point. If no intersection
+     * is found, hit_point and hit_distance are not modified.
+     * 
+     * @param origin        The starting point of the ray
+     * @param heading       The direction of the ray as a vector
+     * @param rect          The rectangle to check for intersection
+     * @param hit_point     The point to set to where the ray intersects the rectangle
+     * @param hit_distance  The double to set to the distance from the ray's origin to
+     *                      the intersection point
+     * @returns             True if the ray intersects the rectangle, false otherwise
+     */
     bool rectangle_ray_intersection(const point_2d &origin, const vector_2d &heading, const rectangle &rect, point_2d &hit_point, double &hit_distance);
 
 }

--- a/coresdk/src/coresdk/triangle_geometry.cpp
+++ b/coresdk/src/coresdk/triangle_geometry.cpp
@@ -7,7 +7,6 @@
 //
 
 #include "geometry.h"
-#include "graphics.h"
 #include <cmath>
 
 #include <vector>
@@ -121,10 +120,7 @@ namespace splashkit_lib
         }
         
         bool has_collision = false;
-
-        int width = screen_width();
-        int height = screen_height();
-        double closest_distance = std::sqrt(width * width + height * height); // Closest intersection distance
+        double closest_distance = __DBL_MAX__;
 
         // Iterate through each edge of the triangle
         for (int i = 0; i < 3; ++i)

--- a/coresdk/src/coresdk/triangle_geometry.h
+++ b/coresdk/src/coresdk/triangle_geometry.h
@@ -47,6 +47,33 @@ namespace splashkit_lib
     bool triangle_rectangle_intersect(const triangle &tri, const rectangle &rect);
 
     /**
+     * Detects if a ray intersects a triangle.
+     * 
+     * @param origin        The starting point of the ray
+     * @param heading       The direction of the ray as a vector
+     * @param tri           The triangle to check for intersection
+     * @returns             True if the ray intersects the triangle, false otherwise
+     */
+    bool triangle_ray_intersection(const point_2d &origin, const vector_2d &heading, const triangle &tri);
+
+    /**
+     * Detects if a ray intersects a triangle. If an intersection is found, the
+     * `hit_point` and `hit_distance` are set to the point of intersection and the
+     * distance from the ray's origin to the intersection point. If the ray's `origin`
+     * is contained within the triangle, `hit_point` is set to the `origin` and `hit_distance`
+     * is set to 0. If no intersection is found, `hit_point` and `hit_distance` are not modified.
+     * 
+     * @param origin        The starting point of the ray
+     * @param heading       The direction of the ray as a vector
+     * @param tri           The triangle to check for intersection
+     * @param hit_point     The point to set to where the ray intersects the triangle
+     * @param hit_distance  The double to set to the distance from the ray's origin to
+     *                      the intersection point
+     * @returns             True if the ray intersects the triangle, false otherwise
+     */
+    bool triangle_ray_intersection(const point_2d &origin, const vector_2d &heading, const triangle &tri, point_2d &hit_point, double &hit_distance);
+
+    /**
      * Returns true if the two triangles intersect.
      *
      * @param  t1 The first triangle

--- a/coresdk/src/test/test_geometry.cpp
+++ b/coresdk/src/test/test_geometry.cpp
@@ -16,7 +16,7 @@ using namespace std;
 
 using namespace splashkit_lib;
 
-enum class shape_type
+enum class geometry_test_shape_type
 {
     RECTANGLE,
     CIRCLE,
@@ -255,31 +255,31 @@ void ray_shape_intersection(const line& l, const point_2d& circ_center, color& c
     clr = COLOR_RED;
 }
 
-shape_type calculate_min_dist_shape(bool rect, bool circ, bool tri, bool quad, double rect_dist,
+geometry_test_shape_type calculate_min_dist_shape(bool rect, bool circ, bool tri, bool quad, double rect_dist,
                                     double circ_dist, double tri_dist, double quad_dist)
 {
     double min_dist = __DBL_MAX__;
-    shape_type result = shape_type::NONE;
+    geometry_test_shape_type result = geometry_test_shape_type::NONE;
 
     if (rect && rect_dist < min_dist)
     {
         min_dist = rect_dist;
-        result = shape_type::RECTANGLE;
+        result = geometry_test_shape_type::RECTANGLE;
     }
     if (circ && circ_dist < min_dist)
     {
         min_dist = circ_dist;
-        result = shape_type::CIRCLE;
+        result = geometry_test_shape_type::CIRCLE;
     }
     if (tri && tri_dist < min_dist)
     {
         min_dist = tri_dist;
-        result = shape_type::TRIANGLE;
+        result = geometry_test_shape_type::TRIANGLE;
     }
     if (quad && quad_dist < min_dist)
     {
         min_dist = quad_dist;
-        result = shape_type::QUAD;
+        result = geometry_test_shape_type::QUAD;
     }
 
     return result;
@@ -337,21 +337,21 @@ void test_rect_circ_tri_ray_intersection()
         t1_color = COLOR_BLUE;
         q1_color = COLOR_BLUE;
 
-        shape_type min_dist_shape = calculate_min_dist_shape(r1_intersection, c1_intersection, t1_intersection, q1_intersection,
+        geometry_test_shape_type min_dist_shape = calculate_min_dist_shape(r1_intersection, c1_intersection, t1_intersection, q1_intersection,
                                                             r1_distance, c1_distance, t1_distance, q1_distance);
 
         switch (min_dist_shape)
         {
-            case shape_type::RECTANGLE:
+            case geometry_test_shape_type::RECTANGLE:
                 ray_shape_intersection(line_from(player, r1_hit_point), r1_hit_point, r1_color);
                 break;
-            case shape_type::CIRCLE:
+            case geometry_test_shape_type::CIRCLE:
                 ray_shape_intersection(line_from(player, c1_hit_point), c1_hit_point, c1_color);
                 break;
-            case shape_type::TRIANGLE:
+            case geometry_test_shape_type::TRIANGLE:
                 ray_shape_intersection(line_from(player, t1_hit_point), t1_hit_point, t1_color);
                 break;
-            case shape_type::QUAD:
+            case geometry_test_shape_type::QUAD:
                 ray_shape_intersection(line_from(player, q1_hit_point), q1_hit_point, q1_color);
                 break;
             default: // shape_type::NONE:

--- a/coresdk/src/test/test_geometry.cpp
+++ b/coresdk/src/test/test_geometry.cpp
@@ -16,6 +16,15 @@ using namespace std;
 
 using namespace splashkit_lib;
 
+enum class shape_type
+{
+    RECTANGLE,
+    CIRCLE,
+    TRIANGLE,
+    QUAD,
+    NONE
+};
+
 void test_points()
 {
     point_2d p = point_at(10, 20);
@@ -239,10 +248,133 @@ void test_triangle()
     close_window(w1);
 }
 
+void ray_shape_intersection(const line& l, const point_2d& circ_center, color& clr)
+{
+    draw_line(COLOR_BLACK, l);
+    fill_circle(COLOR_RED, circle_at(circ_center, 5.0));
+    clr = COLOR_RED;
+}
+
+shape_type calculate_min_dist_shape(bool rect, bool circ, bool tri, bool quad, double rect_dist,
+                                    double circ_dist, double tri_dist, double quad_dist)
+{
+    double min_dist = __DBL_MAX__;
+    shape_type result = shape_type::NONE;
+
+    if (rect && rect_dist < min_dist)
+    {
+        min_dist = rect_dist;
+        result = shape_type::RECTANGLE;
+    }
+    if (circ && circ_dist < min_dist)
+    {
+        min_dist = circ_dist;
+        result = shape_type::CIRCLE;
+    }
+    if (tri && tri_dist < min_dist)
+    {
+        min_dist = tri_dist;
+        result = shape_type::TRIANGLE;
+    }
+    if (quad && quad_dist < min_dist)
+    {
+        min_dist = quad_dist;
+        result = shape_type::QUAD;
+    }
+
+    return result;
+}
+
+void test_rect_circ_tri_ray_intersection()
+{
+    auto r1 = rectangle_from(100.0, 100.0, 100.0, 100.0);
+    auto r1_color = COLOR_BLUE;
+    auto r1_hit_point = point_at(0.0, 0.0);
+    double r1_distance = 0.0;
+    bool r1_intersection = false;
+    auto c1 = circle_at(300.0, 200.0, 60.0);
+    auto c1_color = COLOR_BLUE;
+    auto c1_hit_point = point_at(0.0, 0.0);
+    double c1_distance = 0.0;
+    bool c1_intersection = false;
+    auto t1 = triangle_from(400.0, 400.0, 550.0, 410.0, 390.0, 550.0);
+    auto t1_color = COLOR_BLUE;
+    auto t1_hit_point = point_at(0.0, 0.0);
+    double t1_distance = 0.0;
+    bool t1_intersection = false;
+    auto q1 = quad_from(100.0, 300.0, 200.0, 350.0, 100.0, 550.0, 200.0, 500.0);
+    auto q1_color = COLOR_BLUE;
+    auto q1_hit_point = point_at(0.0, 0.0);
+    double q1_distance = 0.0;
+    bool q1_intersection = false;
+    auto player = point_at(300.0, 300.0);
+
+    window w1 = open_window("Ray Intersection Tests", 600, 800);
+    while ( !window_close_requested(w1) ) {
+        process_events();
+        
+        clear_screen(COLOR_WHEAT);
+
+        if (key_down(UP_KEY))
+            player.y -= 1;
+        if (key_down(DOWN_KEY))
+            player.y += 1;
+        if (key_down(LEFT_KEY))
+            player.x -= 1;
+        if (key_down(RIGHT_KEY))
+            player.x += 1;
+
+        vector_2d player_heading = vector_point_to_point(player, mouse_position());
+        vector_2d player_unit_heading = unit_vector(player_heading);
+
+        r1_intersection = rectangle_ray_intersection(player, player_unit_heading, r1, r1_hit_point, r1_distance);
+        c1_intersection = circle_ray_intersection(player, player_unit_heading, c1, c1_hit_point, c1_distance);
+        t1_intersection = triangle_ray_intersection(player, player_unit_heading, t1, t1_hit_point, t1_distance);
+        q1_intersection = quad_ray_intersection(player, player_unit_heading, q1, q1_hit_point, q1_distance);
+
+        r1_color = COLOR_BLUE;
+        c1_color = COLOR_BLUE;
+        t1_color = COLOR_BLUE;
+        q1_color = COLOR_BLUE;
+
+        shape_type min_dist_shape = calculate_min_dist_shape(r1_intersection, c1_intersection, t1_intersection, q1_intersection,
+                                                            r1_distance, c1_distance, t1_distance, q1_distance);
+
+        switch (min_dist_shape)
+        {
+            case shape_type::RECTANGLE:
+                ray_shape_intersection(line_from(player, r1_hit_point), r1_hit_point, r1_color);
+                break;
+            case shape_type::CIRCLE:
+                ray_shape_intersection(line_from(player, c1_hit_point), c1_hit_point, c1_color);
+                break;
+            case shape_type::TRIANGLE:
+                ray_shape_intersection(line_from(player, t1_hit_point), t1_hit_point, t1_color);
+                break;
+            case shape_type::QUAD:
+                ray_shape_intersection(line_from(player, q1_hit_point), q1_hit_point, q1_color);
+                break;
+            default: // shape_type::NONE:
+                draw_line(COLOR_BLACK, player, point_offset_by(player, vector_multiply(player_unit_heading, 1000.0)));
+        };
+
+        draw_rectangle(r1_color, r1);
+        draw_circle(c1_color, c1);
+        draw_triangle(t1_color, t1);
+        draw_quad(q1_color, q1);
+
+        draw_circle(COLOR_BLACK, circle_at(player, 5.0));
+
+        refresh_screen();
+    }
+    close_window(w1);
+}
+
 void run_geometry_test()
 {
     test_rectangle();
     test_points();
     test_lines();
     test_triangle();
+    test_rect_circ_tri_ray_intersection();
 }


### PR DESCRIPTION
# Description

There has been growing interest in using SplashKit to perform ray-tracing in both 2D and 3D environments. However, there is a lack of ray-based intersection functions with primitive shapes. I have added ray intersection functions for rectangles, circles, triangles, and quads.

Each shape has been given a function which can output the the intersection position and distance. I have also included an overload of each function that only returns a Boolean. By including the overload, the user is not required to pass arguments by reference which may be confusing to SIT102 students.

I collaborated with Shaun Ratcliff to complete the logic for the intersection functions.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I added a new real-time graphical test to `sktest` in `test_geometry.cpp` to demonstrate the functions. It allows the user to move a ray's origin with the arrow keys, while the heading is determined by the mouse cursor's position. All four shapes are present for testing. If an intersection occurs, the corresponding shape is highlighted and the intersection point is shown.

## Testing Checklist

- [x] Tested with sktest

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings