### PR TITLE
Clipping and geometry bug fixes

### DIFF
--- a/coresdk/src/coresdk/clipping.cpp
+++ b/coresdk/src/coresdk/clipping.cpp
@@ -53,7 +53,6 @@ namespace splashkit_lib
             LOG(WARNING) << "Attempting to push clip rect to invalid window";
             return;
         }
-
         _push_clip(wnd->image, r);
     }
 
@@ -119,7 +118,7 @@ namespace splashkit_lib
 
         if ( img.clip_stack.size() > 0 )
         {
-            rectangle clip_rect = *img.clip_stack.end();
+            rectangle clip_rect = img.clip_stack.back();
             sk_set_clip_rect(&img.surface, clip_rect.x, clip_rect.y, clip_rect.width, clip_rect.height);
         }
         else
@@ -158,7 +157,7 @@ namespace splashkit_lib
     rectangle _current_clip(const image_data &img)
     {
         if (img.clip_stack.size() > 0)
-            return *img.clip_stack.end();
+            return img.clip_stack.back();
         else
             return rectangle_from(0, 0, img.surface.width, img.surface.height);
     }

--- a/coresdk/src/coresdk/line_geometry.cpp
+++ b/coresdk/src/coresdk/line_geometry.cpp
@@ -109,8 +109,11 @@ namespace splashkit_lib
     point_2d closest_point_on_lines(const point_2d from_pt, const vector<line> &lines, int &line_idx)
     {
         line_idx = -1;
-        float min_dist = -1, dst;
         point_2d result = point_at_origin();
+
+        if (lines.size() < 1) return result;
+
+        float min_dist = std::numeric_limits<float>::max(), dst;
         point_2d pt;
 
         for (int i = 0; i < lines.size(); i++)
@@ -125,7 +128,7 @@ namespace splashkit_lib
                 result = pt;
             }
         }
-        return pt;
+        return result;
     }
 
     vector<line> lines_from(const triangle &t)

--- a/coresdk/src/coresdk/line_geometry.cpp
+++ b/coresdk/src/coresdk/line_geometry.cpp
@@ -109,11 +109,8 @@ namespace splashkit_lib
     point_2d closest_point_on_lines(const point_2d from_pt, const vector<line> &lines, int &line_idx)
     {
         line_idx = -1;
+        float min_dist = -1, dst;
         point_2d result = point_at_origin();
-
-        if (lines.size() < 1) return result;
-
-        float min_dist = std::numeric_limits<float>::max(), dst;
         point_2d pt;
 
         for (int i = 0; i < lines.size(); i++)
@@ -128,7 +125,7 @@ namespace splashkit_lib
                 result = pt;
             }
         }
-        return result;
+        return pt;
     }
 
     vector<line> lines_from(const triangle &t)

--- a/coresdk/src/coresdk/point_geometry.cpp
+++ b/coresdk/src/coresdk/point_geometry.cpp
@@ -107,7 +107,7 @@ namespace splashkit_lib
         v = (dot00 * dot12 - dot01 * dot02) * inv_denom;
 
         // Check if point is in triangle
-        return ((u > 0) and (v > 0) and (u + v < 1));
+        return ((u >= 0) and (v >= 0) and (u + v <= 1));
     }
 
     bool point_in_rectangle(const point_2d &pt, const rectangle &rect)

--- a/coresdk/src/coresdk/quad_geometry.cpp
+++ b/coresdk/src/coresdk/quad_geometry.cpp
@@ -61,7 +61,7 @@ namespace splashkit_lib
 
     void set_quad_point(quad &q, int idx, const point_2d &value)
     {
-        if (idx < 0 || idx > 3)
+        if (idx >= 0 && idx <= 3)
         {
             q.points[idx] = value;
         }

--- a/coresdk/src/coresdk/vector_2d.cpp
+++ b/coresdk/src/coresdk/vector_2d.cpp
@@ -116,7 +116,9 @@ namespace splashkit_lib
 
     double angle_between(const vector_2d &v1, const vector_2d &v2)
     {
-        return vector_angle( vector_subtract(v2, v1) );
+        double dot = dot_product(v1, v2);
+        double det = v1.x * v2.y - v1.y * v2.x;
+        return rad_to_deg(atan2(det, dot));
     }
 
     vector_2d vector_normal(const vector_2d &v)


### PR DESCRIPTION
## Description

I have addressed several issues related to clipping, geometry calculations, and bounds checking. Below is a breakdown of the problems encountered and how I fixed them:

Fixes # [issue].

1. **_current_clip and _pop_clip**

   - **Problem:** The code originally used `end` to reference the last element in the array, but `end` actually refers to the element after the last element, which caused incorrect references.
   - **Fix:** I updated the code to use `back` instead of `end`, which correctly references the last element in the array.


2. **point_in_triangle**

   - **Problem:** The collision detection for points within a triangle had an issue where points on the edges, corners, or diagonals of the triangle were not correctly registered as being inside the triangle. This occurred because the barycentric coordinate check used strict inequalities (> and <) instead of inclusive inequalities (>= and <=).
   - **Fix:** I updated it to use inclusive inequalities, ensuring that points on the edges and corners of the triangle (and the quads derived from triangles) are correctly detected as inside the shape, fixing the collision detection for boundary points.


3. **quad_point**

   - **Problem:** The bounds checking for quad point modifications had an inverted logic error. It would only set the point value when the index was outside the valid range (less than 0 or greater than 3), which caused out-of-bounds access and undefined behavior.
   - **Fix:** I corrected the bounds checking logic to set the point value only when the index is within the valid range (0 to 3 inclusive), preventing memory corruption and ensuring proper handling of quad points.


4. **angle_between**

   - **Problem:** The original `angle_between` function calculated the angle of the difference vector between two vectors rather than the actual angle between them. This led to incorrect results (e.g., a 135° angle for vectors that should have been 90° apart).
   - **Fix:** I updated it to correctly calculate the angle between two vectors using `atan2`. By computing the angle based on the dot product and determinant of the vectors, the function now returns results in the expected range of [-180°, 180°]. Positive values indicate counterclockwise rotation, and negative values indicate clockwise rotation.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

I have tested these fixes across multiple scenarios:

- Validated that the code correctly handles boundary points in triangles.
- Ensured proper angle calculation between vectors with different orientations.
- Verified that bounds checking for quad points works correctly.


## Testing Checklist

- [x] Tested with my test generator and all tests pass.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
