### PR TITLE
Fixing Up Bug For RPi cmake Initialization

### DIFF
--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -18,8 +18,18 @@ if (WIN32 OR MSYS OR MINGW)
 endif()
 
 # Check for Raspberry Pi
+execute_process(COMMAND uname -m OUTPUT_VARIABLE ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+if (EXISTS "/sys/firmware/devicetree/base/model")
+    file(READ "/sys/firmware/devicetree/base/model" DEVICE_MODEL)
+endif()
+
+if (ARCH MATCHES "armv7l|aarch64|armv6l" OR DEVICE_MODEL MATCHES "Raspberry Pi")
+    message(STATUS "Raspberry Pi detected: ${ARCH} ${DEVICE_MODEL}")
+    set(IS_RASPBERRY_PI TRUE)
+    add_definitions(-DRASPBERRY_PI)
+endif()
+
 include(CheckIncludeFile)
-find_path(BCM_HOST_INCLUDE_DIR bcm_host.h PATHS "/opt/vc/include")
 #### SETUP ####
 if (APPLE)
     # MAC OS PROJECT FLAGS
@@ -105,6 +115,11 @@ else()
                    -ldl \
                    -lstdc++fs")
 endif()
+
+find_path(BCM_HOST_INCLUDE_DIR bcm_host.h 
+    HINTS /usr/include /usr/local/include /opt/vc/include 
+    PATH_SUFFIXES interface/vcos/pthreads interface/vmcs_host/linux
+)
 
 if (BCM_HOST_INCLUDE_DIR)
     message("Raspberry Pi detected")
@@ -287,3 +302,4 @@ set_target_properties(skunit_tests
 
 install(TARGETS SplashKitBackend DESTINATION lib)
 install(FILES ${INCLUDE_FILES} DESTINATION include/SplashKitBackend)
+

--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -23,7 +23,7 @@ if (EXISTS "/sys/firmware/devicetree/base/model")
     file(READ "/sys/firmware/devicetree/base/model" DEVICE_MODEL)
 endif()
 
-if (ARCH MATCHES "armv7l|aarch64|armv6l" OR DEVICE_MODEL MATCHES "Raspberry Pi")
+if (ARCH MATCHES "armv7l|aarch64|armv6l" AND DEVICE_MODEL MATCHES "Raspberry Pi")
     message(STATUS "Raspberry Pi detected: ${ARCH} ${DEVICE_MODEL}")
     set(IS_RASPBERRY_PI TRUE)
     add_definitions(-DRASPBERRY_PI)


### PR DESCRIPTION
# Description

This code fixes up the issues of being able to not detect the Raspberry Pi device on the Raspberry Pi when cmake .  is done. This is because the BCM_HOST_INCLUDE_DIR bcm_host.h file doesn't exist anymore in the opt/vc/include directory and instead, it's in usr/local/include for me. The lines between 119 and 123 find this path but it's done by checking multiple path options before choosing the one that aligns with the RPi configuration.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has been tested when I run in the splashkit folder the cd projects/make, the cmake . and the make lines in Linux where it now shows that it recognises the Pi, I then in the sktest ran the tests 22 and 24 on the RPi itself and it worked since these tests need to be able to recognise the local RPi.

## Testing Checklist

- [x] Tested with sktest

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
