### PR TITLE
Fix UI ID generation

### DIFF
--- a/coresdk/src/backend/interface_driver.cpp
+++ b/coresdk/src/backend/interface_driver.cpp
@@ -636,10 +636,10 @@ namespace splashkit_lib
         return temp_value;
     }
 
-    std::string sk_interface_text_box(const std::string& id, const std::string& value)
+    std::string sk_interface_text_box(const std::string& value)
     {
-        // const std::string* id = &value; 
-        mu_Id m_id = mu_get_id(ctx, id.c_str(), id.length());
+        const std::string* id = &value;
+        mu_Id m_id = mu_get_id(ctx, &id, sizeof(id));
         mu_Rect r = mu_layout_next(ctx);
 
         // max 512 characters

--- a/coresdk/src/backend/interface_driver.cpp
+++ b/coresdk/src/backend/interface_driver.cpp
@@ -29,6 +29,27 @@ namespace splashkit_lib
 
     static mu_Id focused_text_box = 0;
 
+    // Hold a stack in parallel to MicroUI's, which we use to
+    // get incrementing IDs for elements which don't require labels
+    static std::vector<mu_Id> id_stack;
+
+    mu_Id _id_stack_next()
+    {
+        id_stack.back()++;
+
+        return mu_get_id(ctx, &id_stack.back(), sizeof(id_stack.back()));
+    }
+
+    void _id_stack_push()
+    {
+        id_stack.push_back(0);
+    }
+
+    void _id_stack_pop()
+    {
+        id_stack.pop_back();
+    }
+
     static bool element_changed = false;
     static bool element_confirmed = false;
 
@@ -430,11 +451,14 @@ namespace splashkit_lib
         mu_get_current_container(ctx)->zindex = -1;
         int widths[] = {0};
         sk_interface_set_layout(1,widths,0);
+
+        _id_stack_push();
     }
 
     void sk_interface_end()
     {
         // end root window
+        _id_stack_pop();
         mu_end_window(ctx);
 
         mu_end(ctx);
@@ -469,41 +493,55 @@ namespace splashkit_lib
 
     bool sk_interface_start_panel(const string& name, rectangle initial_rectangle)
     {
-        return mu_begin_window(ctx, name.c_str(), to_mu(initial_rectangle));
+        bool open = mu_begin_window(ctx, name.c_str(), to_mu(initial_rectangle));
+        if (open) _id_stack_push();
+
+        return open;
     }
 
     void sk_interface_end_panel()
     {
+        _id_stack_pop();
         mu_end_window(ctx);
     }
 
     bool sk_interface_start_popup(const string& name)
     {
-        return mu_begin_popup(ctx, name.c_str());
+        bool open = mu_begin_popup(ctx, name.c_str());
+        if (open) _id_stack_push();
+
+        return open;
     }
 
     void sk_interface_end_popup()
     {
+        _id_stack_pop();
         mu_end_popup(ctx);
     }
 
     void sk_interface_start_inset(const string& name)
     {
         mu_begin_panel(ctx, name.c_str());
+        _id_stack_push();
     }
 
     void sk_interface_end_inset()
     {
+        _id_stack_pop();
         mu_end_panel(ctx);
     }
 
     bool sk_interface_start_treenode(const string& name)
     {
-        return mu_begin_treenode(ctx, name.c_str());
+        bool open = mu_begin_treenode(ctx, name.c_str());
+        if (open) _id_stack_push();
+
+        return open;
     }
 
     void sk_interface_end_treenode()
     {
+        _id_stack_pop();
         mu_end_treenode(ctx);
     }
 
@@ -572,9 +610,10 @@ namespace splashkit_lib
         element_confirmed = result & MU_RES_SUBMIT;
     }
 
-    void sk_interface_push_ptr_id(void* ptr)
+    void sk_interface_push_temp_id()
     {
-        mu_push_id(ctx, &ptr, sizeof(ptr));
+        mu_Id id = _id_stack_next();
+        mu_push_id(ctx, &id, sizeof(id));
     }
 
     void sk_interface_pop_id()
@@ -605,7 +644,7 @@ namespace splashkit_lib
 
     bool sk_interface_checkbox(const string& label_text, const bool& value)
     {
-        sk_interface_push_ptr_id((void*)&value);
+        sk_interface_push_temp_id();
 
         int temp_value = value;
         update_elements_changed(mu_checkbox(ctx, label_text.c_str(), &temp_value));
@@ -616,7 +655,7 @@ namespace splashkit_lib
 
     float sk_interface_slider(const float& value, float min_value, float max_value)
     {
-        sk_interface_push_ptr_id((void*)&value);
+        sk_interface_push_temp_id();
 
         float temp_value = value;
         update_elements_changed(mu_slider(ctx, &temp_value, min_value, max_value));
@@ -627,7 +666,7 @@ namespace splashkit_lib
 
     float sk_interface_number(const float& value, float step)
     {
-        sk_interface_push_ptr_id((void*)&value);
+        sk_interface_push_temp_id();
 
         float temp_value = value;
         update_elements_changed(mu_number(ctx, &temp_value, step));
@@ -638,8 +677,7 @@ namespace splashkit_lib
 
     std::string sk_interface_text_box(const std::string& value)
     {
-        const std::string* id = &value;
-        mu_Id m_id = mu_get_id(ctx, &id, sizeof(id));
+        mu_Id m_id = _id_stack_next();
         mu_Rect r = mu_layout_next(ctx);
 
         // max 512 characters

--- a/coresdk/src/backend/interface_driver.h
+++ b/coresdk/src/backend/interface_driver.h
@@ -61,7 +61,7 @@ namespace splashkit_lib
     bool sk_interface_checkbox(const string& label_text, const bool& value);
     float sk_interface_slider(const float& value, float min_value, float max_value);
     float sk_interface_number(const float& value, float step);
-    std::string sk_interface_text_box(const std::string& id, const std::string& value);
+    std::string sk_interface_text_box(const std::string& value);
 
     void sk_interface_color_box(color clr);
 

--- a/coresdk/src/backend/interface_driver.h
+++ b/coresdk/src/backend/interface_driver.h
@@ -51,7 +51,7 @@ namespace splashkit_lib
     int sk_interface_get_layout_width();
     int sk_interface_get_layout_height();
 
-    void sk_interface_push_ptr_id(void* ptr);
+    void sk_interface_push_temp_id();
     void sk_interface_pop_id();
 
     bool sk_interface_header(const string& label_text);

--- a/coresdk/src/coresdk/interface.cpp
+++ b/coresdk/src/coresdk/interface.cpp
@@ -1134,37 +1134,32 @@ namespace splashkit_lib
 
     std::string text_box(const string& label_text, const std::string& value)
     {
-        return text_box(label_text, value, false);
-    }
-
-    std::string text_box(const string& label_text, const std::string& value, bool show_label)
-    {
         _interface_sanity_check();
 
-        if (show_label)
-        {
-            enter_column();
-            _two_column_layout();
+        enter_column();
+        _two_column_layout();
 
-            splashkit_lib::label_element(label_text);
-        }
+        splashkit_lib::label_element(label_text);
+        std::string res = text_box(value);
 
-        std::string res = sk_interface_text_box(label_text, value);
-
-        if (show_label)
-        {
-            leave_column();
-        }
+        leave_column();
 
         return res;
     }
 
-    std::string text_box(const string& label_text, const string& value, const rectangle& rect)
+    std::string text_box(const string& value, const rectangle& rect)
     {
         _interface_sanity_check();
 
         sk_interface_set_layout_next(rect, true);
-        return text_box(label_text, value, false);
+        return text_box(value);
+    }
+
+    std::string text_box(const std::string& value)
+    {
+        _interface_sanity_check();
+
+        return sk_interface_text_box(value);
     }
 
     bool last_element_changed()

--- a/coresdk/src/coresdk/interface.cpp
+++ b/coresdk/src/coresdk/interface.cpp
@@ -990,7 +990,7 @@ namespace splashkit_lib
         _interface_sanity_check();
         enter_column();
 
-        sk_interface_push_ptr_id((void*)&clr);
+        sk_interface_push_temp_id();
 
         color temp_value = clr;
         if (hsb)

--- a/coresdk/src/coresdk/interface.h
+++ b/coresdk/src/coresdk/interface.h
@@ -645,29 +645,13 @@ namespace splashkit_lib
      * my_string = text_box("Name", my_string);
      * ```
      *
-     * @param label_text        Unique identifier for the text box (not drawn)
+     * @param label_text        The label to show in front of the text box
      * @param value             The current value of the text box
-     * @return                  The updated value of the text box
-     */
-    string text_box(const string& label_text, const string& value);
-
-    /**
-     * Creates a text entry box with a label that can be shown.
-     * Returns the updated value of the text box.
-     *
-     * Example usage:
-     * ```c++
-     * my_string = text_box("Name", my_string, true);
-     * ```
-     *
-     * @param label_text        Unique identifier for the text box (not drawn)
-     * @param value             The current value of the text box
-     * @param show_label        Whether to show the label or not
      * @return                  The updated value of the text box
      *
      * @attribute suffix        labeled
      */
-    string text_box(const string& label_text, const string& value, bool show_label);
+    string text_box(const string& label_text, const string& value);
 
     /**
      * Creates a text entry box at a specific position on screen.
@@ -675,17 +659,24 @@ namespace splashkit_lib
      *
      * Example usage:
      * ```c++
-     * my_string = text_box("Name", my_string, rectangle_from(0,0,100,100));
+     * my_string = text_box("Name", my_string);
      * ```
      *
-     * @param label_text        Unique identifier for the text box (not drawn)
      * @param value             The current value of the text box
      * @param rect              The rectangle to display the button in
      * @return                  The updated value of the text box
      *
      * @attribute suffix        at_position
      */
-    string text_box(const string& label_text, const string& value, const rectangle& rect);
+    string text_box(const string& value, const rectangle& rect);
+
+    /**
+     * Creates a text entry box with a label.
+     * Returns the updated value of the text box.
+     * @param value             The current value of the text box
+     * @return                  The updated value of the text box
+     */
+    string text_box(const string& value);
 
     /**
      * Returns if the last created element was changed at all (such as dragged, typed in, etc)

--- a/coresdk/src/test/test_ui.cpp
+++ b/coresdk/src/test/test_ui.cpp
@@ -28,11 +28,13 @@ void run_ui_test()
 
     // Some variables to test the elements with
     bool checkbox_val = false;
+    bool checkbox_val2 = false;
     float val1 = 0;
     float val2 = 0;
     float val3 = 0;
     std::string text_box_val1 = "Type here!";
     std::string text_box_val2 = "And here!";
+    std::string text_box_val3 = "Option text";
 
     // A sprite to test bitmap buttons
     animation_script player_animations = load_animation_script("player_animations", "player_animations.txt");
@@ -165,6 +167,17 @@ void run_ui_test()
 
         if (start_panel("Second Window", rectangle_from(300, 200, 240, 186)))
         {
+            checkbox_val2 = checkbox("ID Handle Check", checkbox_val2);
+            if (checkbox_val2)
+            {
+                start_inset("Options", 25);
+                    text_box_val3 = text_box("Text:", text_box_val3);
+                end_inset("Options");
+                start_inset("Options2", 25);
+                    text_box_val3 = text_box("Text:", text_box_val3);
+                end_inset("Options2");
+            }
+
             start_inset("TreeView", -25);
                 if (start_treenode("Node1"))
                 {
@@ -181,6 +194,20 @@ void run_ui_test()
                     button("Hello again!");
                     checkbox("It works right?", true);
                     end_treenode("Node2");
+                }
+                if (start_treenode("ID Test 2"))
+                {
+                    // This demonstrates an edge case with the current ID system
+                    // Focus on Box 1 will switch back and forth between it and Box 2
+                    // This test can be used to check if future work has fixed this
+                    static int time = 0;
+                    time += 1;
+                    if (time % 120 < 60)
+                    {
+                        text_box_val1 = text_box("Box 1:", text_box_val1);
+                    }
+                    text_box_val2 = text_box("Box 2:", text_box_val2);
+                    end_treenode("ID Test 2");
                 }
 
             end_inset("TreeView");

--- a/coresdk/src/test/test_ui.cpp
+++ b/coresdk/src/test/test_ui.cpp
@@ -146,13 +146,13 @@ void run_ui_test()
                 val3 = number_box("Number: ", val3, 1.0);
 
                 // Show two text boxes
-                text_box_val1 = text_box("V1", text_box_val1);
+                text_box_val1 = text_box("Text:", text_box_val1);
                 if (last_element_confirmed())
                 {
                     checkbox_val = true;
                 }
                 set_interface_font(fontB);
-                text_box_val2 = text_box("Text:", text_box_val2, true);
+                text_box_val2 = text_box("Text:", text_box_val2);
                 set_interface_font(fontA);
             }
 
@@ -195,7 +195,7 @@ void run_ui_test()
             write_line("Button1 pressed");
         }
         val2 = slider(val2, 0, 40, {40, 170, 150, 20});
-        text_box_val2 = text_box("V2", text_box_val2, rectangle_from(40, 200, 150, 20));
+        text_box_val2 = text_box(text_box_val2, rectangle_from(40, 200, 150, 20));
 
         interface_style_panel(rectangle_from(0, 600-200, 600, 200));
 

--- a/coresdk/src/test/test_ui.cpp
+++ b/coresdk/src/test/test_ui.cpp
@@ -132,7 +132,7 @@ void run_ui_test()
                 val1 = slider("Slider", val1, -25, 25);
 
                 // Show two sliders without labels
-                val2 = slider(val2, 0, 100);
+                val2 = slider(val2, 0, 40);
                 val3 = slider(val3, -25, 25);
 
                 // Show checkbox that's checked when we drag the slider

--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(splashkit)
 
-set(CMAKE_BUILD_TYPE Debug)
-
 cmake_policy(SET CMP0083 NEW)
 include(CheckPIESupported)
 check_pie_supported()


### PR DESCRIPTION
# Description

### Context
The current UI system automatically generates IDs for each element to handle focus/other stateful aspects. For many elements, the IDs are generated based on the address of the input variable passed in (for instance the text box's string, the checkbox state, slider value, etc). This doesn't work once the SplashKit translation layers are involved, leading to state being incorrectly shared between different UI elements.

This PR attempts to improve this by keeping track of each element's index within its context (panel/popup/inset/treenode). Rather than using the input variable's address for the ID, it just uses an incrementing number that is contained to that context.

### How it works
This interacts with MicroUI's own context stack to work properly. MicroUI already contains a context stack, which contains an ID for each panel/popup/inset/treenode in the current stack, generated from their label (which is required).

When we generate IDs for the UI elements via `mu_get_id`, it uses the ID for the current context as a base. 

So all we need to do is keep track of an integer incrementing from 0 within the context, and provide that to `mu_get_id` rather than the input value's address - MicroUI will handle making this integer unique in each context.

### Known Issues
This works well for most types of interfaces - the only edge cases I can think of are when the interface changes _during_ an interaction. For instance when a text box is focused (let's say its ID is `2`), if a different text box appears above it within the same context while the user is typing, focus will switch to that text box (since _that_ text box now has ID `2`, while the one the user was typing in has become `3`). This can be seen in the `ID Test 2` section of the UI test.

Future work can involve anchoring the IDs when labels are known (since text inputs, checkboxes, etc, _may_ have a label).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The existing UI test has been checked to ensure things still work. Checking that the state of unrelated elements don't affect each other (unless in the case above) has been tested. The fail case above has also been added as a test to demonstrate it.

This hasn't been tested when ran through translation layers however - I can't foresee any issues (since it isn't using the variable addresses anymore), but that doesn't mean there aren't any :sweat_smile: 

## Testing Checklist

- [x] Tested with sktest
- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
