### PR TITLE
Fix incorrect pin addresses for CH1 to CH7

### DIFF
--- a/coresdk/src/coresdk/raspi_adc.cpp
+++ b/coresdk/src/coresdk/raspi_adc.cpp
@@ -39,19 +39,19 @@ namespace splashkit_lib
         case ADC_PIN_0:
             return 0x84; // CH0
         case ADC_PIN_1:
-            return 0x85; // CH1
+            return 0xC4; // CH1
         case ADC_PIN_2:
-            return 0x86; // CH2
+            return 0x94; // CH2
         case ADC_PIN_3:
-            return 0x87; // CH3
+            return 0xD4; // CH3
         case ADC_PIN_4:
-            return 0x88; // CH4
+            return 0xA4; // CH4
         case ADC_PIN_5:
-            return 0x89; // CH5
+            return 0xE4; // CH5
         case ADC_PIN_6:
-            return 0x8A; // CH6
+            return 0xB4; // CH6
         case ADC_PIN_7:
-            return 0x8B; // CH7
+            return 0xF4; // CH7
         default:
             return -1; // Invalid pin
         }

--- a/coresdk/src/coresdk/raspi_adc.h
+++ b/coresdk/src/coresdk/raspi_adc.h
@@ -17,24 +17,17 @@ namespace splashkit_lib
 {
     /**
      * The `adc_device` type is used to refer to ADC (Analog-to-Digital Converter)
-     * devices that can be managed by the SplashKit ADC code. ADC devices are:
+     * devices that can be managed by the SplashKit ADC code, such as ADS7830.
+     * ADC devices are:
      *
-     *   - loaded with `load_adc_device`,
-     *
+     *   - loaded with `open_adc`,
      *   - accessed using `adc_device_named` or checked with `has_adc_device`,
-     *
-     *   - read using `read_adc_channel` to retrieve analog values from specific channels,
-     *
-     *   - and must be released using `free_adc_device` (to release a specific
-     *     ADC device) or `free_all_adc_devices` (to release all loaded ADC devices).
+     *   - read using `read_adc` to retrieve analog values from specific channels,
+     *   - and must be closed using `close_adc` (to release a specific
+     *     ADC device) or `close_all_adc` (to release all loaded ADC devices).
      *
      * ADC devices allow you to interface with external analog sensors or inputs,
      * converting their signals into digital values for processing in your application.
-     *
-     * You can check if an ADC device is loaded using `has_adc_device`.
-     *
-     * Use `free_adc_device` to release resources associated with a specific ADC device,
-     * or `free_all_adc_devices` to clean up all ADC devices.
      *
      * @attribute class adc_device
      */

--- a/coresdk/src/test/test_raspi_adc.cpp
+++ b/coresdk/src/test/test_raspi_adc.cpp
@@ -1,17 +1,21 @@
-// created by XQuestCode || Aditya Parmar
+//
+//  test_raspi_adc.cpp
+//  splashkit
+//
+
 #include <iostream>
 #include "raspi_gpio.h"
 #include "input.h"
+#include "input_driver.h"
 
 using namespace std;
 using namespace splashkit_lib;
 
-void run_gpio_adc_tests()
+void run_potentiometer_test(gpio_pin end_test_button)
 {
+    cout << "ADC Test 1: Using a Potentiometer with ADC device: ADS7830" << endl;
+    cout << "- Connect a potentiometer to A0 channel on the ADS7830 device" << endl;
 
-    cout << "Testing ADC with a ADS7830 and a potentiometer" << endl;
-    raspi_init();
-    cout << "Plug a potentiometer at A0 channel of the ADS7830" << endl;
     adc_device dev = open_adc("ADC1", 1, 0x48, ADS7830);
     if (dev == nullptr)
     {
@@ -19,15 +23,93 @@ void run_gpio_adc_tests()
         return;
     }
 
-    adc_pin channel = ADC_PIN_0; // Change this to the desired channel
+    adc_pin channel = ADC_PIN_0; // Can change this to the desired channel
     int value = 0;
-    while (!any_key_pressed())
+
+    while (raspi_read(end_test_button) != GPIO_HIGH)
     {
         value = read_adc(dev, channel);
         cout << "ADC value: " << value << endl;
     }
 
     close_adc(dev);
+    cout << "ADC potentiometer test completed." << endl;
+}
+
+void run_joystick_test(gpio_pin end_test_button)
+{
+    cout << "Test 2: Testing ADC (ADS7830) using a Joystick module." << endl;
+    cout << "- Connect VRx to A1 channel on the ADS7830 device." << endl;
+    cout << "- Connect VRy to A2 channel on the ADS7830 device." << endl;
+
+    adc_device adc = open_adc("ADC1", 1, 0x48, ADS7830);
+    if (adc == nullptr)
+    {
+        cout << "Failed to open ADC device." << endl;
+        return;
+    }
+
+    // Joystick movement values
+    int joystick_x;
+    int joystick_y;
+
+    while (raspi_read(end_test_button) != GPIO_HIGH)
+    {
+        joystick_x = read_adc(adc, ADC_PIN_1);
+        joystick_y = read_adc(adc, ADC_PIN_2);
+
+        cout << "\033[2J\033[H" << endl;
+        cout << "Joystick values:" << endl;
+        cout << "  VRx: " << joystick_x << "\tVRy: " << joystick_y << endl;
+    }
+
+    // Clean up
+    close_adc(adc);
+}
+
+void run_gpio_adc_tests()
+{
+    const int NUMBER_OF_ADC_TESTS = 2; // Update this if more tests are added
+
+    cout << endl;
+    cout << "ADC Tests:" << endl;
+    cout << endl;
+    cout << "Note: The following GPIO tests require a button to wired to pin 7 to allow the test to be stopped cleanly." << endl;
+    cout << endl;
+
+    int user_input = 0;
+    while (user_input < 1 || user_input > NUMBER_OF_ADC_TESTS)
+    {
+        cout << "ADC Tests using ADC device: ADS7830" << endl;
+        cout << "1: Potentiometer test" << endl;
+        cout << "2: Joystick test" << endl;
+        cout << "------------------------" << endl;
+        cout << "Select ADC test to run: ";
+        cin >> user_input;
+        cin.ignore();
+    }
+
+    // Initialise GPIO & I2C
+    raspi_init();
+
+    // Set up button for ending the program
+    gpio_pin end_button_pin = PIN_7;
+    raspi_set_mode(end_button_pin, GPIO_INPUT);
+    raspi_set_pull_up_down(end_button_pin, PUD_DOWN);
+
+    switch (user_input)
+    {
+    case 1:
+        run_potentiometer_test(end_button_pin);
+        break;
+    case 2:
+        run_joystick_test(end_button_pin);
+        break;
+    default:
+        break;
+    }
+
+    // Clean up
     raspi_cleanup();
-    cout << "ADC test completed." << endl;
+    cout << "ADC test complete." << endl;
 }

--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -149,6 +149,7 @@ if (NOT APPLE AND NOT MSYS)
             message("-- Pigpio libraries found")
             include_directories(${PIGPIOD_INCLUDE_DIR})
             add_definitions(-DRASPBERRY_PI)
+            add_definitions(-DELPP_NO_DEFAULT_LOG_FILE)
             # Override LIB_FLAGS for Raspberry Pi to include pigpiod_if2
             set(LIB_FLAGS "-lSDL2 \
                            -lSDL2_mixer \


### PR DESCRIPTION
# Description

This PR addresses the issue where channels A1-A7 on the ADS7830 device were not being recognised due to incorrect pin addresses in the `_get_ads7830_pin_address` function.

---

From page 13 and 14 of the [ADS7830 datasheet](https://www.ti.com/lit/ds/symlink/ads7830.pdf), it explains that the analog channels are controlled by the "Command Byte".

The **first** 4 bits:

- The first 4 bits of the "command byte" are used to select each channel address. This is shown in Table 2 on page 14. 
- In this table, the first column (SD) will always be "1" as we are only expecting "Single-Ended Inputs" to the device.
- From there, we can find the first 4 bits of each channel by locating the row with "+IN" showing in that channel's column (in the lower half of the table), and then checking the values in the first 4 columns (SD C2 C1 C0).

The **last** 4 bits:

- The last 4 bits will be the same for all channels, and can be found using Table 1 on page 13.
- The Power-Down Selection for this device is using the "Internal Reference OFF and A/D Converter ON", which gives PD1 and PD0 values of 0 and 1 respectively, which gives a value of `0100` (as the last 2 bits are unused).

This can be verified by the fact that channel A0 (which is working correctly) has an address of `0x84`. This is `10000100` in binary (aka `1000` for CH0 in Table 2, and `0100` for the Power-Down Selection in Table 1 mentioned above).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I used this [Joystick Module](https://media.jaycar.com.au/product/resources/XC4422_datasheetMain_67849.pdf), with the "VRX" pin connected to A0 on the ADS7830 device (as a control), and then connected the "VRY" pin to each of the other analog pins, one at a time.

**Test circuit**:

*Note: The button on the breadboard is just used as a way to end the program.*

<img width="1764" height="1122" alt="joystick-with-adc_bb" src="https://github.com/user-attachments/assets/2100a49a-49b0-4149-8a59-55eefe8c6c2c" />

**Test code**:

```cpp
#include "splashkit.h"

using std::to_string;

int main()
{
    // Initialise GPIO & I2C
    raspi_init();

    // Set up button for ending the program
    gpio_pin end_button_pin = PIN_7;
    raspi_set_mode(end_button_pin, GPIO_INPUT);
    raspi_set_pull_up_down(end_button_pin, PUD_DOWN);

    // Set up analog joystick movement
    adc_device adc = open_adc("ADC1", 1, 0x48, ADS7830);
    int joystick_x;
    int joystick_y;

    while (raspi_read(end_button_pin) != GPIO_HIGH)
    {
        joystick_x = read_adc(adc, ADC_PIN_0); // A0 channel used as a control for test
        joystick_y = read_adc(adc, ADC_PIN_7); // The adc_pin channel was updated for each test run

        write_line("\033[2J\033[H");
        write_line("Joystick values:");
        write_line("VRx: " + to_string(joystick_x) + "\tVRy: " + to_string(joystick_y));

        delay(16); // Equivalent to ~60 fps
    }

    // Clean up
    close_adc(adc);
    raspi_cleanup();
    return 0;
}
```

**Output showing independent x and y control**:

![joystick values](https://github.com/user-attachments/assets/68ccc7af-88b2-4a24-9991-ab22abd119af)

Note: I also updated the `test_raspi_adc.cpp` file to fix the current potentiometer test and include a joystick test similar to the code above.

## Testing Checklist

- [x] Tested with sktest
- [x] Tested with skunit_tests (N/A)



## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
